### PR TITLE
ci: auto-migrate Drizzle + Supabase on Vercel build

### DIFF
--- a/.claude/docs/supabase-setup.md
+++ b/.claude/docs/supabase-setup.md
@@ -175,16 +175,34 @@ Also confirm **Project Settings → General → Node.js Version** is `24.x` (or 
 
 ### Step 5 — Push migrations to production
 
+Migrations run automatically on every Vercel build via the `vercel-build` script (`scripts/ci-migrate.mjs`). Push to `main` → prod build runs Drizzle + Supabase migrations against the prod DB → Next builds → deploy. Push any other branch → same flow against the preview DB.
+
+**Required Vercel env vars (per scope — Preview + Production):**
+
+| Var | Value | Notes |
+|---|---|---|
+| `SUPABASE_DB_PASSWORD` | raw DB password | script URL-encodes for you — paste it raw |
+| `SUPABASE_DB_HOST` | e.g. `aws-0-us-west-1.pooler.supabase.com` | session-pooler host (port 5432) |
+| `SUPABASE_PROJECT_REF` | e.g. `fyuasgpjrphxrituofsm` | the project ref slug |
+
+Add via dashboard or CLI:
+
 ```bash
-# One-time: link your local CLI to the cloud project
-supabase link --project-ref <your-project-ref>
+printf 'RAW_PASSWORD' | vercel env add SUPABASE_DB_PASSWORD production
+printf 'aws-0-us-west-1.pooler.supabase.com' | vercel env add SUPABASE_DB_HOST production
+printf 'fyuasgpjrphxrituofsm' | vercel env add SUPABASE_PROJECT_REF production
+# repeat for preview scope (dashboard for preview — CLI prompts non-interactively)
+```
 
-# Push Drizzle-generated schema migrations
-DATABASE_URL=<prod-pooler-url> npx drizzle-kit migrate
+**Manual override / fallback** — if you ever need to push migrations by hand (e.g. CI is down or you want to dry-run):
 
-# Push Supabase migrations (RLS + triggers + cleanup functions)
+```bash
+supabase link --project-ref <ref>
+DATABASE_URL=<prod-session-pooler-url> npx drizzle-kit migrate
 supabase db push
 ```
+
+**Skip migrations for a deploy** — set `SKIP_MIGRATIONS=1` in Vercel env, redeploy. Useful for infra-only changes when the script itself is broken.
 
 ### Step 6 — Verify
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
             "eslint-config-next": "^15.0.0",
             "postcss": "^8.4.49",
             "server-only": "^0.0.1",
+            "supabase": "^2.106.0",
             "tailwindcss": "^4.0.0",
             "typescript": "^5.6.3",
             "vitest": "^2.1.5"
@@ -2570,6 +2571,118 @@
          "engines": {
             "node": ">=20.0.0"
          }
+      },
+      "node_modules/@supabase/cli-darwin-arm64": {
+         "version": "2.106.0",
+         "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-arm64/-/cli-darwin-arm64-2.106.0.tgz",
+         "integrity": "sha512-xi/IAjjbebh6xA9Nkkb7ZwC5ACKJ38OqMoYk1y20ScW5Wt+pxTCcOcaWDWu+2u2Pwc3vTYnXhbknVcQt9UcChQ==",
+         "cpu": [
+            "arm64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "darwin"
+         ]
+      },
+      "node_modules/@supabase/cli-darwin-x64": {
+         "version": "2.106.0",
+         "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-x64/-/cli-darwin-x64-2.106.0.tgz",
+         "integrity": "sha512-AT2s/8/3Ffb7IkcUXK6sA/iPCzJhh4Fh/XqzAGNGsVd1xCA/ZGniqU8BL03TqPkN1sR0iDaShjMLLIlHEflyPQ==",
+         "cpu": [
+            "x64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "darwin"
+         ]
+      },
+      "node_modules/@supabase/cli-linux-arm64": {
+         "version": "2.106.0",
+         "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64/-/cli-linux-arm64-2.106.0.tgz",
+         "integrity": "sha512-L/pX7fkV31x7zPrUOcD6KMtZ03j16o41XxgkACFoOAE9lFz8KaJOBSHvn2QLeWEa2kLz7jwpisvpshPSMjuxOw==",
+         "cpu": [
+            "arm64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@supabase/cli-linux-arm64-musl": {
+         "version": "2.106.0",
+         "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.106.0.tgz",
+         "integrity": "sha512-2LExuOHuU6odXorNTvq4M/OvueW+wOs3KDsaCpk+scQMnB6LbmqNidEjXAsKpZu3zyE8MmmtdbJBlRNN/KLdcw==",
+         "cpu": [
+            "arm64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@supabase/cli-linux-x64": {
+         "version": "2.106.0",
+         "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64/-/cli-linux-x64-2.106.0.tgz",
+         "integrity": "sha512-+ihtqFNURc8ssULgQoHQBR4AtUmxez9dtqjclqOV0y5r65SX7Ginmiby4XDW9LPlqHT+MB7OyD1vk0T6pQUtPA==",
+         "cpu": [
+            "x64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@supabase/cli-linux-x64-musl": {
+         "version": "2.106.0",
+         "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64-musl/-/cli-linux-x64-musl-2.106.0.tgz",
+         "integrity": "sha512-wz7heB3wwzmRdLRgqngd2VjPPNIdv6/Y8Q0dX/ZvjcL9/Nk8BYSZ7yjypapLpra+swRnbEJ4jAU6eAShiaB1Hg==",
+         "cpu": [
+            "x64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "linux"
+         ]
+      },
+      "node_modules/@supabase/cli-windows-arm64": {
+         "version": "2.106.0",
+         "resolved": "https://registry.npmjs.org/@supabase/cli-windows-arm64/-/cli-windows-arm64-2.106.0.tgz",
+         "integrity": "sha512-QkEfRDiuuQwcfASo2DIJZ59AFV6xpqhPNo4r0kSVt38StYk3iL7ZcSOkZvGQWLlJ8kXKPBWEMhLnfHQF9r+Xfg==",
+         "cpu": [
+            "arm64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "win32"
+         ]
+      },
+      "node_modules/@supabase/cli-windows-x64": {
+         "version": "2.106.0",
+         "resolved": "https://registry.npmjs.org/@supabase/cli-windows-x64/-/cli-windows-x64-2.106.0.tgz",
+         "integrity": "sha512-1tQFbrH1KJhWJqHrY087XPz1WRi20eKG1pebG+6PjSD6XN+j0+x1PTOtBZrylXgY1fOg8BqgU8kl3KX8hI5l9w==",
+         "cpu": [
+            "x64"
+         ],
+         "dev": true,
+         "license": "MIT",
+         "optional": true,
+         "os": [
+            "win32"
+         ]
       },
       "node_modules/@supabase/functions-js": {
          "version": "2.108.1",
@@ -8599,6 +8712,26 @@
             "babel-plugin-macros": {
                "optional": true
             }
+         }
+      },
+      "node_modules/supabase": {
+         "version": "2.106.0",
+         "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.106.0.tgz",
+         "integrity": "sha512-jV0PJi5LqXUMZ4kriRLvST3DX1YDhrxOgnFJLOn6oUw3KQEFJPXhA60yLQ9aWG1E1uZCp4vUJwSuSGq3HPfaSQ==",
+         "dev": true,
+         "license": "MIT",
+         "bin": {
+            "supabase": "dist/supabase.js"
+         },
+         "optionalDependencies": {
+            "@supabase/cli-darwin-arm64": "2.106.0",
+            "@supabase/cli-darwin-x64": "2.106.0",
+            "@supabase/cli-linux-arm64": "2.106.0",
+            "@supabase/cli-linux-arm64-musl": "2.106.0",
+            "@supabase/cli-linux-x64": "2.106.0",
+            "@supabase/cli-linux-x64-musl": "2.106.0",
+            "@supabase/cli-windows-arm64": "2.106.0",
+            "@supabase/cli-windows-x64": "2.106.0"
          }
       },
       "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
       "dev": "next dev",
       "dev:lan": "node scripts/dev-lan.mjs",
       "build": "next build",
+      "vercel-build": "node scripts/ci-migrate.mjs && next build",
       "start": "next start",
       "lint": "next lint",
       "test": "vitest",
@@ -45,6 +46,7 @@
       "eslint-config-next": "^15.0.0",
       "postcss": "^8.4.49",
       "server-only": "^0.0.1",
+      "supabase": "^2.106.0",
       "tailwindcss": "^4.0.0",
       "typescript": "^5.6.3",
       "vitest": "^2.1.5"

--- a/scripts/ci-migrate.mjs
+++ b/scripts/ci-migrate.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Runs on Vercel build (vercel-build hook).
+// 1. URL-encodes SUPABASE_DB_PASSWORD and constructs the session-pooler URL.
+// 2. Runs drizzle-kit migrate against it.
+// 3. Runs `supabase db push --db-url ...` for RLS / triggers / functions.
+//
+// Required env vars (set per scope in Vercel — Preview + Production):
+//   SUPABASE_DB_PASSWORD  raw password, no URL encoding
+//   SUPABASE_DB_HOST      e.g. aws-0-us-west-1.pooler.supabase.com
+//   SUPABASE_PROJECT_REF  e.g. fyuasgpjrphxrituofsm
+//
+// Local builds (no VERCEL env) skip migrations entirely.
+// Set SKIP_MIGRATIONS=1 on Vercel to bypass (e.g. infra-only deploys).
+
+import { spawnSync } from 'node:child_process';
+
+const isVercel = process.env.VERCEL === '1';
+const skip = process.env.SKIP_MIGRATIONS === '1';
+
+if (!isVercel) {
+   console.log('[ci-migrate] not a Vercel build (VERCEL!=1) — skipping migrations.');
+   process.exit(0);
+}
+
+if (skip) {
+   console.log('[ci-migrate] SKIP_MIGRATIONS=1 — skipping migrations.');
+   process.exit(0);
+}
+
+const env = process.env.VERCEL_ENV ?? 'unknown';
+console.log(`[ci-migrate] Vercel build (env=${env}). Running migrations.`);
+
+const required = ['SUPABASE_DB_PASSWORD', 'SUPABASE_DB_HOST', 'SUPABASE_PROJECT_REF'];
+const missing = required.filter((k) => !process.env[k]);
+if (missing.length) {
+   console.error(`[ci-migrate] missing env vars: ${missing.join(', ')}`);
+   process.exit(1);
+}
+
+const password = process.env.SUPABASE_DB_PASSWORD;
+const host = process.env.SUPABASE_DB_HOST;
+const ref = process.env.SUPABASE_PROJECT_REF;
+
+const encodedPassword = encodeURIComponent(password);
+const migrationUrl = `postgresql://postgres.${ref}:${encodedPassword}@${host}:5432/postgres`;
+
+const safeUrl = migrationUrl.replace(encodedPassword, '***');
+console.log(`[ci-migrate] migration target: ${safeUrl}`);
+
+function run(label, cmd, args, extraEnv = {}) {
+   console.log(`\n[ci-migrate] ▶ ${label}: ${cmd} ${args.join(' ')}`);
+   const result = spawnSync(cmd, args, {
+      stdio: 'inherit',
+      env: { ...process.env, ...extraEnv },
+   });
+   if (result.status !== 0) {
+      console.error(`[ci-migrate] ✗ ${label} failed (exit ${result.status}).`);
+      process.exit(result.status ?? 1);
+   }
+   console.log(`[ci-migrate] ✓ ${label} done.`);
+}
+
+run('drizzle-kit migrate', 'npx', ['drizzle-kit', 'migrate'], { DATABASE_URL: migrationUrl });
+
+run('supabase db push', 'npx', [
+   'supabase',
+   'db',
+   'push',
+   '--db-url',
+   migrationUrl,
+   '--include-all',
+]);
+
+console.log('\n[ci-migrate] all migrations applied.');

--- a/scripts/ci-migrate.mjs
+++ b/scripts/ci-migrate.mjs
@@ -48,7 +48,8 @@ const safeUrl = migrationUrl.replace(encodedPassword, '***');
 console.log(`[ci-migrate] migration target: ${safeUrl}`);
 
 function run(label, cmd, args, extraEnv = {}) {
-   console.log(`\n[ci-migrate] ▶ ${label}: ${cmd} ${args.join(' ')}`);
+   const printable = args.map((a) => (a === migrationUrl ? '<redacted-url>' : a));
+   console.log(`\n[ci-migrate] ▶ ${label}: ${cmd} ${printable.join(' ')}`);
    const result = spawnSync(cmd, args, {
       stdio: 'inherit',
       env: { ...process.env, ...extraEnv },


### PR DESCRIPTION
## Summary
- Add `scripts/ci-migrate.mjs` + `vercel-build` hook so every Vercel build runs `drizzle-kit migrate` then `supabase db push` against the env-scoped DB.
- Reads `SUPABASE_DB_PASSWORD` (raw), `SUPABASE_DB_HOST`, `SUPABASE_PROJECT_REF` from Vercel env. Script URL-encodes the password so no more hand-encoding.
- Local builds (`VERCEL!=1`) skip migrations. `SKIP_MIGRATIONS=1` escape hatch for infra-only deploys.
- Adds `supabase` as a devDep so the CLI is available in the Vercel build sandbox.
- `run()` helper redacts the migration URL when logging so the DB password never lands in build logs.

## Test plan
- [x] Preview build green against preview Supabase (`iosokzbammerxzyfuboc`) — 4 pending supabase migrations applied automatically.
- [x] Build log verified clean (`<redacted-url>` instead of password).
- [ ] Prod build green on merge → prod Supabase (`fyuasgpjrphxrituofsm`) migrations apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)