### PR TITLE
feat: button loaders for navigation + async actions

### DIFF
--- a/app/HomeClient.tsx
+++ b/app/HomeClient.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 import { useParallax } from '@/client/hooks/useParallax';
-import { PirateButton } from '@/ui/pirate-button/PirateButton';
+import { PirateLinkButton } from '@/ui/pirate-button/PirateLinkButton';
 
 /**
  * Landing hero — full-bleed key art (night cove, public/hero/home-cove.webp)
@@ -12,7 +11,6 @@ import { PirateButton } from '@/ui/pirate-button/PirateButton';
  * pointer/device tilt; the title counter-shifts to sell the depth.
  */
 export default function HomeClient() {
-   const router = useRouter();
    const parallaxRef = useParallax();
 
    return (
@@ -99,15 +97,15 @@ export default function HomeClient() {
                <span className='block text-[color:var(--color-coral-400)]'>Bank what ye dare.</span>
                <span className='block text-[color:var(--color-orchid-400)]'>Beware of pirates — or lose it all.</span>
             </p>
-            <PirateButton
+            <PirateLinkButton
+               href='/choose-game'
                variant='primary'
                size='lg'
                fullWidth
-               onClick={() => router.push('/choose-game')}
                className='text-2xl sm:text-3xl'
             >
                Set Sail
-            </PirateButton>
+            </PirateLinkButton>
             <span className='text-sm uppercase tracking-[0.35em] text-[color:var(--color-cream-200)]/55 [text-shadow:0_1px_8px_rgb(2_6_15/0.9)]'>
                Press to play
             </span>

--- a/app/choose-game/ChooseGameClient.tsx
+++ b/app/choose-game/ChooseGameClient.tsx
@@ -1,12 +1,9 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { PirateButton } from '@/ui/pirate-button/PirateButton';
+import { PirateLinkButton } from '@/ui/pirate-button/PirateLinkButton';
 import { PiratePanel } from '@/ui/pirate-panel/PiratePanel';
 
 export default function ChooseGameClient() {
-   const router = useRouter();
-
    return (
       <main className='scrollbar-none flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-5 py-6 safe-bottom sm:py-10'>
          <header className='flex flex-col gap-1 text-center'>
@@ -25,9 +22,9 @@ export default function ChooseGameClient() {
                glow='teal-glow'
                subtitle='Pass the device around. 2–10 crewmates duel for doubloons on one screen.'
                action={
-                  <PirateButton variant='primary' size='lg' fullWidth onClick={() => router.push('/setup')}>
+                  <PirateLinkButton href='/setup' variant='primary' size='lg' fullWidth>
                      Play Local
-                  </PirateButton>
+                  </PirateLinkButton>
                }
             />
             <ModeCard
@@ -39,12 +36,12 @@ export default function ChooseGameClient() {
                subtitle='Sail against friends on other devices. Real-time, server-authoritative, no peeking at the deck.'
                action={
                   <div className='flex flex-col gap-2'>
-                     <PirateButton variant='secondary' size='lg' fullWidth onClick={() => router.push('/play/new')}>
+                     <PirateLinkButton href='/play/new' variant='secondary' size='lg' fullWidth>
                         Charter Ship
-                     </PirateButton>
-                     <PirateButton variant='tertiary' size='md' fullWidth onClick={() => router.push('/play/lobby')}>
+                     </PirateLinkButton>
+                     <PirateLinkButton href='/play/lobby' variant='tertiary' size='md' fullWidth>
                         Find Crew
-                     </PirateButton>
+                     </PirateLinkButton>
                   </div>
                }
             />

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { PirateButton } from '@/ui/pirate-button/PirateButton';
+import { PirateLinkButton } from '@/ui/pirate-button/PirateLinkButton';
 
 export default function NotFound() {
-   const router = useRouter();
    return (
       <main className='scrollbar-none flex min-h-0 flex-1 flex-col items-center justify-center gap-4 overflow-y-auto px-5 py-10 text-center safe-bottom'>
          <div className='pirate-display text-7xl text-[color:var(--color-treasure-400)]'>404</div>
@@ -14,9 +12,9 @@ export default function NotFound() {
          <p className='max-w-md text-sm text-[color:var(--color-cream-200)]/75'>
             This page be buried deep, or it never existed. Navigate yerself back to safer waters.
          </p>
-         <PirateButton variant='primary' size='md' onClick={() => router.push('/')}>
+         <PirateLinkButton href='/' variant='primary' size='md'>
             Sail Home
-         </PirateButton>
+         </PirateLinkButton>
       </main>
    );
 }

--- a/app/play-local/PlayLocalClient.tsx
+++ b/app/play-local/PlayLocalClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { useGameStore } from '@/client/stores/gameStore';
 import { useGameJuice, type JuiceSnapshot } from '@/client/hooks/useGameJuice';
@@ -27,6 +27,7 @@ const PLAYERS_KEY = 'players';
 
 export default function PlayLocalClient({ variant = DEFAULT_VARIANT }: Props) {
    const router = useRouter();
+   const [changingCrew, startChangeCrew] = useTransition();
    const state = useGameStore((s) => s.state);
    const dispatch = useGameStore((s) => s.dispatch);
    const reset = useGameStore((s) => s.reset);
@@ -178,7 +179,13 @@ export default function PlayLocalClient({ variant = DEFAULT_VARIANT }: Props) {
             ranked={ranked}
             actions={
                <>
-                  <PirateButton variant='tertiary' size='md' fullWidth onClick={() => router.push('/setup')}>
+                  <PirateButton
+                     variant='tertiary'
+                     size='md'
+                     fullWidth
+                     loading={changingCrew}
+                     onClick={() => startChangeCrew(() => router.push('/setup'))}
+                  >
                      Change Crew
                   </PirateButton>
                   <PirateButton variant='treasure' size='md' fullWidth onClick={playAgain}>

--- a/app/play/[code]/JoinGate.tsx
+++ b/app/play/[code]/JoinGate.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 import { PirateButton } from '@/ui/pirate-button/PirateButton';
+import { PirateLinkButton } from '@/ui/pirate-button/PirateLinkButton';
 import { PirateModal } from '@/ui/pirate-modal/PirateModal';
 import { PiratePanel } from '@/ui/pirate-panel/PiratePanel';
 import { requestJoin } from '@/server/actions/requestJoin';
@@ -15,6 +15,7 @@ export default function JoinGate({ code, isPublic }: { code: string; isPublic: b
    const router = useRouter();
    const [error, setError] = useState<string | null>(null);
    const [submitting, setSubmitting] = useState(false);
+   const [exiting, startExit] = useTransition();
    const [pending, setPending] = useState<Pending>(null);
    const [deniedOpen, setDeniedOpen] = useState(false);
    const [boarding, setBoarding] = useState(false);
@@ -47,7 +48,7 @@ export default function JoinGate({ code, isPublic }: { code: string; isPublic: b
       // eslint-disable-next-line react-hooks/exhaustive-deps
    }, [isPublic]);
 
-   const exitToPort = () => router.push('/choose-game');
+   const exitToPort = () => startExit(() => router.push('/choose-game'));
 
    // Private path — render the modal only. The auto-knock fires on
    // mount; until the server returns a pending row, show a "hailing"
@@ -91,7 +92,7 @@ export default function JoinGate({ code, isPublic }: { code: string; isPublic: b
                   <p className='text-sm text-[color:var(--color-cream-200)]/85'>
                      The captain has turned ye away from this voyage. Find another ship to plunder with.
                   </p>
-                  <PirateButton variant='primary' size='lg' fullWidth onClick={exitToPort}>
+                  <PirateButton variant='primary' size='lg' fullWidth loading={exiting} onClick={exitToPort}>
                      Return to docks
                   </PirateButton>
                </div>
@@ -100,7 +101,7 @@ export default function JoinGate({ code, isPublic }: { code: string; isPublic: b
                <PirateModal open dismissible={false} title="Couldn't hail">
                   <div className='flex flex-col items-center gap-3 text-center'>
                      <p className='text-sm text-[color:var(--color-coral-500)]'>{error}</p>
-                     <PirateButton variant='primary' size='md' fullWidth onClick={exitToPort}>
+                     <PirateButton variant='primary' size='md' fullWidth loading={exiting} onClick={exitToPort}>
                         Back to port
                      </PirateButton>
                   </div>
@@ -120,14 +121,12 @@ export default function JoinGate({ code, isPublic }: { code: string; isPublic: b
             <span className='wordmark-gold-mono text-5xl tracking-[0.45em] [text-indent:0.45em]'>{code}</span>
             <p className='text-sm text-[color:var(--color-cream-200)]/80'>Ready to board this voyage?</p>
             {error && <p className='text-sm text-[color:var(--color-coral-500)]'>{error}</p>}
-            <PirateButton variant='primary' size='lg' fullWidth onClick={board} disabled={submitting}>
-               {submitting ? 'Boarding…' : 'Board the ship'}
+            <PirateButton variant='primary' size='lg' fullWidth onClick={board} loading={submitting}>
+               Board the ship
             </PirateButton>
-            <Link href='/choose-game' className='w-full'>
-               <PirateButton variant='tertiary' size='md' fullWidth>
-                  Back to port
-               </PirateButton>
-            </Link>
+            <PirateLinkButton href='/choose-game' variant='tertiary' size='md' fullWidth>
+               Back to port
+            </PirateLinkButton>
          </PiratePanel>
       </main>
    );

--- a/app/play/[code]/OnlineRoomClient.tsx
+++ b/app/play/[code]/OnlineRoomClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import {
    useGameRoom,
@@ -64,6 +64,10 @@ export default function OnlineRoomClient({
    initialContinuation,
 }: Props) {
    const router = useRouter();
+   const [leaving, startLeave] = useTransition();
+   const goToLobby = useCallback(() => {
+      startLeave(() => router.push('/play/lobby'));
+   }, [router]);
    const wasMember = useRef(initial.players.some((p) => p.id === userId));
    const [knocks, setKnocks] = useState<KnockEntry[]>([]);
    const [hostLeaveCandidates, setHostLeaveCandidates] = useState<Candidate[] | null>(null);
@@ -380,7 +384,8 @@ export default function OnlineRoomClient({
                   variant='primary'
                   size='lg'
                   fullWidth
-                  onClick={() => router.push('/play/lobby')}
+                  loading={leaving}
+                  onClick={goToLobby}
                >
                   Return to docks
                </PirateButton>
@@ -402,7 +407,8 @@ export default function OnlineRoomClient({
                   variant='primary'
                   size='lg'
                   fullWidth
-                  onClick={() => router.push('/play/lobby')}
+                  loading={leaving}
+                  onClick={goToLobby}
                >
                   Return to docks
                </PirateButton>
@@ -447,7 +453,8 @@ export default function OnlineRoomClient({
                onlineIds={onlineIds}
                isSpectator={isSpectator}
                isPublic={isPublic}
-               onLeave={() => router.push('/play/lobby')}
+               onLeave={goToLobby}
+               navLeaving={leaving}
                onLeaveAsHost={handleLeaveHost}
             />
             {sharedModals}
@@ -469,7 +476,8 @@ export default function OnlineRoomClient({
                onlineIds={onlineIds}
                isSpectator={isSpectator}
                isPublic={isPublic}
-               onLeave={() => router.push('/play/lobby')}
+               onLeave={goToLobby}
+               navLeaving={leaving}
                onLeaveAsHost={handleLeaveHost}
                continuationDeadline={continuation?.deadlineAt}
                pendingIds={pendingIds}
@@ -493,7 +501,8 @@ export default function OnlineRoomClient({
             applyOptimistic={applyOptimistic}
             onlineIds={onlineIds}
             isSpectator={isSpectator}
-            onLeave={() => router.push('/play/lobby')}
+            onLeave={goToLobby}
+               navLeaving={leaving}
             continuationDeadline={continuation?.deadlineAt ?? null}
             onContinue={handleContinue}
             onJumpShip={handleJumpShip}
@@ -528,7 +537,8 @@ function ContinueButton({
          size='md'
          fullWidth
          onClick={click}
-         disabled={submitting || secs <= 0}
+         loading={submitting}
+         disabled={secs <= 0}
       >
          <span className='inline-flex items-center gap-2'>
             Continue
@@ -609,6 +619,7 @@ function Lobby({
    isSpectator,
    isPublic,
    onLeave,
+   navLeaving,
    onLeaveAsHost,
    continuationDeadline,
    pendingIds,
@@ -623,6 +634,7 @@ function Lobby({
    isSpectator: boolean;
    isPublic: boolean;
    onLeave: () => void;
+   navLeaving: boolean;
    onLeaveAsHost: () => void;
    continuationDeadline?: string;
    pendingIds?: ReadonlySet<string>;
@@ -806,16 +818,28 @@ function Lobby({
                   <span className='text-[color:var(--color-cream-200)]/75'>
                      Spectating — seat opens next round.
                   </span>
-                  <PirateButton variant='ghost' size='sm' onClick={handleLeaveSpectator} disabled={leaving}>
-                     {leaving ? '…' : 'Leave'}
+                  <PirateButton
+                     variant='ghost'
+                     size='sm'
+                     onClick={handleLeaveSpectator}
+                     loading={leaving || navLeaving}
+                  >
+                     Leave
                   </PirateButton>
                </div>
             ) : continuationDeadline ? (
                <ContinuationWaitingButton deadlineAt={continuationDeadline} />
             ) : isHost ? (
                <div className='flex flex-col gap-2'>
-                  <PirateButton variant='primary' size='lg' fullWidth onClick={start} disabled={!canStart || starting}>
-                     {starting ? 'Setting sail…' : 'Hoist the Colors!'}
+                  <PirateButton
+                     variant='primary'
+                     size='lg'
+                     fullWidth
+                     onClick={start}
+                     disabled={!canStart}
+                     loading={starting}
+                  >
+                     Hoist the Colors!
                   </PirateButton>
                   {!canStart && (
                      <p className='text-center text-xs text-[color:var(--color-cream-200)]/60'>
@@ -840,9 +864,9 @@ function Lobby({
                         await leaveRoom(code);
                         onLeave();
                      }}
-                     disabled={leaving}
+                     loading={leaving || navLeaving}
                   >
-                     {leaving ? '…' : 'Disembark'}
+                     Disembark
                   </PirateButton>
                </div>
             )}
@@ -892,6 +916,7 @@ function Play({
    onlineIds,
    isSpectator,
    onLeave,
+   navLeaving,
    continuationDeadline,
    onContinue,
    onJumpShip,
@@ -905,6 +930,7 @@ function Play({
    onlineIds: ReadonlySet<string>;
    isSpectator: boolean;
    onLeave: () => void;
+   navLeaving: boolean;
    continuationDeadline: string | null;
    onContinue: () => void | Promise<void>;
    onJumpShip: () => void | Promise<void>;
@@ -1118,9 +1144,9 @@ function Play({
                      variant='ghost'
                      size='sm'
                      onClick={handleLeaveSpectator}
-                     disabled={leavingSpectate}
+                     loading={leavingSpectate || navLeaving}
                   >
-                     {leavingSpectate ? '…' : 'Leave room'}
+                     Leave room
                   </PirateButton>
                </div>
             ) : !isCurrent ? (
@@ -1128,8 +1154,15 @@ function Play({
                   Waiting on {currentPlayer?.name ?? 'the helm'}…
                </p>
             ) : isPirate ? (
-               <PirateButton variant='tertiary' size='lg' fullWidth disabled={pending !== null} onClick={handleEndTurn}>
-                  {pending === 'end' ? '…' : 'Pass the Helm'}
+               <PirateButton
+                  variant='tertiary'
+                  size='lg'
+                  fullWidth
+                  loading={pending === 'end'}
+                  disabled={pending !== null}
+                  onClick={handleEndTurn}
+               >
+                  Pass the Helm
                </PirateButton>
             ) : (
                <div className='flex gap-3'>
@@ -1138,16 +1171,20 @@ function Play({
                      size='lg'
                      fullWidth
                      onClick={handleDraw}
-                     disabled={!canDraw || pending !== null}>
-                     {pending === 'draw' ? '…' : 'Plunder'}
+                     loading={pending === 'draw'}
+                     disabled={!canDraw || pending !== null}
+                  >
+                     Plunder
                   </PirateButton>
                   <PirateButton
                      variant='secondary'
                      size='lg'
                      fullWidth
                      onClick={handleBank}
-                     disabled={!canBank || pending !== null}>
-                     {pending === 'bank' ? '…' : 'Bury It'}
+                     loading={pending === 'bank'}
+                     disabled={!canBank || pending !== null}
+                  >
+                     Bury It
                   </PirateButton>
                </div>
             )}
@@ -1166,7 +1203,7 @@ function Play({
                         size='md'
                         fullWidth
                         onClick={handleLeaveSpectator}
-                        disabled={leavingSpectate}
+                        loading={leavingSpectate || navLeaving}
                      >
                         To port
                      </PirateButton>

--- a/app/play/[code]/SpectateGate.tsx
+++ b/app/play/[code]/SpectateGate.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 import { PirateButton } from '@/ui/pirate-button/PirateButton';
+import { PirateLinkButton } from '@/ui/pirate-button/PirateLinkButton';
 import { PirateModal } from '@/ui/pirate-modal/PirateModal';
 import { PiratePanel } from '@/ui/pirate-panel/PiratePanel';
 import { requestJoin } from '@/server/actions/requestJoin';
@@ -21,6 +21,7 @@ export default function SpectateGate({
    const router = useRouter();
    const [error, setError] = useState<string | null>(null);
    const [submitting, setSubmitting] = useState(false);
+   const [returning, startReturn] = useTransition();
    const [pending, setPending] = useState<Pending>(null);
    const [deniedOpen, setDeniedOpen] = useState(false);
    const autoFired = useRef(false);
@@ -78,20 +79,18 @@ export default function SpectateGate({
                   size='lg'
                   fullWidth
                   onClick={watch}
-                  disabled={submitting}
+                  loading={submitting}
                >
-                  {submitting ? 'Climbing aboard…' : cta}
+                  {cta}
                </PirateButton>
             ) : (
                <p className='animate-pulse text-xs uppercase tracking-[0.3em] text-[color:var(--color-gold-300)]'>
                   Awaitin&apos; the captain&apos;s word
                </p>
             )}
-            <Link href='/choose-game' className='w-full'>
-               <PirateButton variant='tertiary' size='md' fullWidth>
-                  Back to port
-               </PirateButton>
-            </Link>
+            <PirateLinkButton href='/choose-game' variant='tertiary' size='md' fullWidth>
+               Back to port
+            </PirateLinkButton>
          </PiratePanel>
 
          <KnockWaitingModal
@@ -123,7 +122,8 @@ export default function SpectateGate({
                   variant='primary'
                   size='lg'
                   fullWidth
-                  onClick={() => router.push('/choose-game')}
+                  loading={returning}
+                  onClick={() => startReturn(() => router.push('/choose-game'))}
                >
                   Return to docks
                </PirateButton>

--- a/app/play/join/JoinClient.tsx
+++ b/app/play/join/JoinClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { PirateButton } from '@/ui/pirate-button/PirateButton';
 import { PiratePanel } from '@/ui/pirate-panel/PiratePanel';
@@ -11,7 +11,7 @@ export default function JoinClient() {
    const { ready } = useCurrentUser();
    const [code, setCode] = useState('');
    const [error, setError] = useState<string | null>(null);
-   const [submitting, setSubmitting] = useState(false);
+   const [submitting, startSubmit] = useTransition();
 
    if (!ready) {
       return (
@@ -31,11 +31,10 @@ export default function JoinClient() {
          return;
       }
       setError(null);
-      setSubmitting(true);
       // Don't try to join here — route to the room page and let JoinGate /
       // SpectateGate decide between direct-board (public) and knock (private).
       // The page handles not-found and visibility-gated paths.
-      router.push(`/play/${trimmed}`);
+      startSubmit(() => router.push(`/play/${trimmed}`));
    };
 
    return (
@@ -71,9 +70,10 @@ export default function JoinClient() {
                   size='lg'
                   fullWidth
                   type='submit'
-                  disabled={submitting || code.trim().length !== 4}
+                  loading={submitting}
+                  disabled={code.trim().length !== 4}
                >
-                  {submitting ? 'Boarding…' : 'Board the ship'}
+                  Board the ship
                </PirateButton>
             </form>
          </PiratePanel>

--- a/app/play/lobby/FindCrewClient.tsx
+++ b/app/play/lobby/FindCrewClient.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 import { PirateButton } from '@/ui/pirate-button/PirateButton';
+import { PirateLinkButton } from '@/ui/pirate-button/PirateLinkButton';
 import { PiratePanel } from '@/ui/pirate-panel/PiratePanel';
 import { requestJoin } from '@/server/actions/requestJoin';
 import {
@@ -15,18 +15,19 @@ export default function FindCrewClient({ initial }: { initial: PublicRoomSummary
    const router = useRouter();
    const rooms = usePublicLobby(initial);
    const [joining, setJoining] = useState<string | null>(null);
+   const [navigating, startNavigation] = useTransition();
    const [error, setError] = useState<string | null>(null);
 
    const board = async (code: string, kind: 'player' | 'spectator') => {
       setJoining(`${code}:${kind}`);
       setError(null);
       const res = await requestJoin({ code, kind });
-      setJoining(null);
       if (!res.ok) {
+         setJoining(null);
          setError(res.error);
          return;
       }
-      router.push(`/play/${code}`);
+      startNavigation(() => router.push(`/play/${code}`));
    };
 
    return (
@@ -39,11 +40,9 @@ export default function FindCrewClient({ initial }: { initial: PublicRoomSummary
          </header>
 
          <div className='flex flex-col gap-2'>
-            <Link href='/play/join' className='w-full'>
-               <PirateButton variant='secondary' size='md' fullWidth>
-                  Have a code? Board a sealed ship
-               </PirateButton>
-            </Link>
+            <PirateLinkButton href='/play/join' variant='secondary' size='md' fullWidth>
+               Have a code? Board a sealed ship
+            </PirateLinkButton>
          </div>
 
          {error && (
@@ -61,11 +60,9 @@ export default function FindCrewClient({ initial }: { initial: PublicRoomSummary
                <p className='text-sm text-[color:var(--color-cream-200)]/70'>
                   No open voyages right now. Charter yer own and let the crew come to ye.
                </p>
-               <Link href='/play/new' className='w-full'>
-                  <PirateButton variant='primary' size='md' fullWidth>
-                     Charter Ship
-                  </PirateButton>
-               </Link>
+               <PirateLinkButton href='/play/new' variant='primary' size='md' fullWidth>
+                  Charter Ship
+               </PirateLinkButton>
             </PiratePanel>
          ) : (
             <ul className='flex flex-col gap-2'>
@@ -80,6 +77,7 @@ export default function FindCrewClient({ initial }: { initial: PublicRoomSummary
                               ? (joining.split(':')[1] as 'player' | 'spectator')
                               : null
                         }
+                        anyJoining={joining !== null || navigating}
                      />
                   </li>
                ))}
@@ -87,11 +85,9 @@ export default function FindCrewClient({ initial }: { initial: PublicRoomSummary
          )}
 
          <div className='mt-auto pt-2 safe-bottom'>
-            <Link href='/choose-game' className='w-full'>
-               <PirateButton variant='tertiary' size='md' fullWidth>
-                  Back to port
-               </PirateButton>
-            </Link>
+            <PirateLinkButton href='/choose-game' variant='tertiary' size='md' fullWidth>
+               Back to port
+            </PirateLinkButton>
          </div>
       </main>
    );
@@ -102,11 +98,13 @@ function RoomRow({
    onBoard,
    onSpectate,
    joiningKind,
+   anyJoining,
 }: {
    room: PublicRoomSummary;
    onBoard: () => void;
    onSpectate: () => void;
    joiningKind: 'player' | 'spectator' | null;
+   anyJoining: boolean;
 }) {
    const isActive = room.status === 'active';
    const seatsFree = room.playerCount < room.maxPlayers;
@@ -145,10 +143,11 @@ function RoomRow({
                   size='sm'
                   fullWidth
                   onClick={onBoard}
-                  disabled={joiningKind !== null}
+                  disabled={anyJoining}
+                  loading={joiningKind === 'player'}
                   title='Take a seat'
                >
-                  {joiningKind === 'player' ? '…' : 'Board'}
+                  Board
                </PirateButton>
             ) : null}
             <PirateButton
@@ -156,10 +155,11 @@ function RoomRow({
                size='sm'
                fullWidth
                onClick={onSpectate}
-               disabled={joiningKind !== null}
+               disabled={anyJoining}
+               loading={joiningKind === 'spectator'}
                title='Watch the voyage'
             >
-               {joiningKind === 'spectator' ? '…' : 'Spectate'}
+               Spectate
             </PirateButton>
          </div>
       </PiratePanel>

--- a/app/play/new/NewRoomClient.tsx
+++ b/app/play/new/NewRoomClient.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 import { createRoom } from '@/server/actions/createRoom';
 import { useCurrentUser } from '@/client/auth/useCurrentUser';
 import { PirateButton } from '@/ui/pirate-button/PirateButton';
+import { PirateLinkButton } from '@/ui/pirate-button/PirateLinkButton';
 import { PiratePanel } from '@/ui/pirate-panel/PiratePanel';
 import { cn } from '@/lib/cn';
 
@@ -16,6 +16,7 @@ export default function NewRoomClient() {
    const { ready } = useCurrentUser();
    const [visibility, setVisibility] = useState<Visibility>('private');
    const [submitting, setSubmitting] = useState(false);
+   const [navigating, startNavigation] = useTransition();
    const [error, setError] = useState<string | null>(null);
 
    if (!ready) {
@@ -33,7 +34,7 @@ export default function NewRoomClient() {
       setError(null);
       const res = await createRoom({ isPublic: visibility === 'public' });
       if (res.ok) {
-         router.push(`/play/${res.code}`);
+         startNavigation(() => router.push(`/play/${res.code}`));
       } else {
          setSubmitting(false);
          setError(res.error);
@@ -73,14 +74,19 @@ export default function NewRoomClient() {
          {error && <p className='text-center text-sm text-[color:var(--color-coral-500)]'>{error}</p>}
 
          <div className='mt-auto flex flex-col gap-2 pt-2 safe-bottom'>
-            <PirateButton variant='primary' size='lg' fullWidth onClick={charter} disabled={submitting}>
-               {submitting ? 'Hoisting…' : 'Set Sail'}
+            <PirateButton
+               variant='primary'
+               size='lg'
+               fullWidth
+               onClick={charter}
+               disabled={submitting || navigating}
+               loading={submitting || navigating}
+            >
+               Set Sail
             </PirateButton>
-            <Link href='/choose-game' className='w-full'>
-               <PirateButton variant='tertiary' size='md' fullWidth>
-                  Back to port
-               </PirateButton>
-            </Link>
+            <PirateLinkButton href='/choose-game' variant='tertiary' size='md' fullWidth>
+               Back to port
+            </PirateLinkButton>
          </div>
       </main>
    );

--- a/app/setup/SetupClient.tsx
+++ b/app/setup/SetupClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { PirateButton } from '@/ui/pirate-button/PirateButton';
 import { PiratePanel } from '@/ui/pirate-panel/PiratePanel';
@@ -15,6 +15,7 @@ interface Player {
 export default function SetupClient() {
    const router = useRouter();
    const inputRef = useRef<HTMLInputElement>(null);
+   const [starting, startTransition] = useTransition();
 
    const [playerName, setPlayerName] = useState('');
    const [players, setPlayers] = useState<Player[]>([]);
@@ -43,7 +44,9 @@ export default function SetupClient() {
 
    const startGame = () => {
       localStorage.setItem('players', JSON.stringify(players));
-      router.push('/play-local');
+      startTransition(() => {
+         router.push('/play-local');
+      });
    };
 
    const canStart = players.length >= MIN_PLAYERS && players.length <= MAX_PLAYERS;
@@ -97,7 +100,14 @@ export default function SetupClient() {
          </div>
 
          <div className='mt-auto pt-2 safe-bottom'>
-            <PirateButton variant='primary' size='lg' fullWidth onClick={startGame} disabled={!canStart}>
+            <PirateButton
+               variant='primary'
+               size='lg'
+               fullWidth
+               onClick={startGame}
+               disabled={!canStart}
+               loading={starting}
+            >
                Hoist the Colors!
             </PirateButton>
             {!canStart && players.length < MIN_PLAYERS && (

--- a/src/ui/pirate-button/PirateButton.tsx
+++ b/src/ui/pirate-button/PirateButton.tsx
@@ -73,20 +73,37 @@ interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
    variant?: Variant;
    size?: Size;
    fullWidth?: boolean;
+   loading?: boolean;
 }
 
 export const PirateButton = forwardRef<HTMLButtonElement, Props>(function PirateButton(
-   { variant = 'primary', size = 'md', fullWidth, className, type = 'button', children, ...rest },
+   {
+      variant = 'primary',
+      size = 'md',
+      fullWidth,
+      loading = false,
+      className,
+      type = 'button',
+      disabled,
+      children,
+      onClick,
+      ...rest
+   },
    ref,
 ) {
+   const isDisabled = disabled || loading;
    return (
       <button
          ref={ref}
          type={type}
+         aria-busy={loading || undefined}
+         disabled={isDisabled}
+         onClick={loading ? undefined : onClick}
          className={cn(
-            'inline-flex items-center justify-center rounded-xl font-display tracking-wider uppercase',
+            'relative inline-flex items-center justify-center rounded-xl font-display tracking-wider uppercase',
             'transition-all duration-100 ease-out',
             'disabled:opacity-45 disabled:cursor-not-allowed',
+            loading && 'cursor-wait disabled:opacity-100',
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--color-coral-400)] focus-visible:ring-offset-2 focus-visible:ring-offset-[color:var(--color-abyss-950)]',
             fullWidth && 'w-full',
             SIZE[size],
@@ -95,7 +112,35 @@ export const PirateButton = forwardRef<HTMLButtonElement, Props>(function Pirate
          )}
          {...rest}
       >
-         {children}
+         <span className={cn('inline-flex items-center justify-center gap-2', loading && 'invisible')}>
+            {children}
+         </span>
+         {loading && (
+            <span className='absolute inset-0 flex items-center justify-center' aria-hidden>
+               <Spinner size={size} />
+            </span>
+         )}
       </button>
    );
 });
+
+function Spinner({ size }: { size: Size }) {
+   const dim = size === 'lg' ? 'h-7 w-7' : size === 'md' ? 'h-6 w-6' : 'h-5 w-5';
+   return (
+      <svg
+         className={cn('animate-spin', dim)}
+         viewBox='0 0 24 24'
+         fill='none'
+         role='status'
+         aria-label='Loading'
+      >
+         <circle cx='12' cy='12' r='9' stroke='currentColor' strokeOpacity='0.25' strokeWidth='3' />
+         <path
+            d='M21 12a9 9 0 0 1-9 9'
+            stroke='currentColor'
+            strokeWidth='3'
+            strokeLinecap='round'
+         />
+      </svg>
+   );
+}

--- a/src/ui/pirate-button/PirateLinkButton.tsx
+++ b/src/ui/pirate-button/PirateLinkButton.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Link, { useLinkStatus, type LinkProps } from 'next/link';
+import { type ReactNode } from 'react';
+import { PirateButton } from './PirateButton';
+
+type ButtonForward = Omit<
+   React.ComponentPropsWithoutRef<typeof PirateButton>,
+   'onClick' | 'type' | 'children' | 'loading'
+>;
+
+interface Props extends ButtonForward {
+   href: LinkProps['href'];
+   prefetch?: LinkProps['prefetch'];
+   replace?: LinkProps['replace'];
+   scroll?: LinkProps['scroll'];
+   children: ReactNode;
+   linkClassName?: string;
+   'aria-label'?: string;
+}
+
+/**
+ * Link that renders a PirateButton and shows the button's loading state
+ * automatically while the destination route is being fetched/rendered.
+ * Uses Next 15's `useLinkStatus` so we get a real pending signal without
+ * having to convert every Link to a `router.push` + `useTransition` pair.
+ */
+export function PirateLinkButton({
+   href,
+   prefetch,
+   replace,
+   scroll,
+   children,
+   linkClassName,
+   fullWidth,
+   ...buttonProps
+}: Props) {
+   return (
+      <Link
+         href={href}
+         prefetch={prefetch}
+         replace={replace}
+         scroll={scroll}
+         className={linkClassName ?? (fullWidth ? 'w-full' : undefined)}
+      >
+         <InnerButton fullWidth={fullWidth} {...buttonProps}>
+            {children}
+         </InnerButton>
+      </Link>
+   );
+}
+
+function InnerButton({
+   children,
+   ...buttonProps
+}: ButtonForward & { children: ReactNode }) {
+   const { pending } = useLinkStatus();
+   return (
+      <PirateButton loading={pending} {...buttonProps}>
+         {children}
+      </PirateButton>
+   );
+}


### PR DESCRIPTION
## Summary

Clicking a CTA used to feel dead until the next route rendered, so users (incl. me) sometimes double-tapped or wondered if the click registered. This adds an in-button spinner that fires the instant a click starts navigation or an async action.

## Approach

- **`PirateButton` — new `loading` prop.** Spinner overlays the label, button keeps its width (no layout shift), click is disabled, `aria-busy` set. Replaces the ad-hoc `'…' / 'Hoisting…'` text patterns scattered around.
- **New `PirateLinkButton`.** Wraps `next/link` + `useLinkStatus` (Next 15) so any Link-driven navigation drives the button's `loading` state automatically — keeps Link prefetch behavior intact.
- **`router.push` call sites use `useTransition`.** `startTransition(() => router.push(…))` makes `isPending` true through the route segment load, which feeds the button's `loading` prop.

## Per-change breakdown

- `src/ui/pirate-button/PirateButton.tsx` — add `loading` prop, spinner, `aria-busy`, click suppression while loading.
- `src/ui/pirate-button/PirateLinkButton.tsx` — new Link wrapper using `useLinkStatus`.
- `app/HomeClient.tsx` — Set Sail → `PirateLinkButton`.
- `app/choose-game/ChooseGameClient.tsx` — Play Local / Charter Ship / Find Crew → `PirateLinkButton`.
- `app/setup/SetupClient.tsx` — Hoist the Colors! wrapped in `useTransition`.
- `app/play-local/PlayLocalClient.tsx` — Victory modal Change Crew in `useTransition`.
- `app/play/new/NewRoomClient.tsx` — Set Sail combines `submitting` (createRoom) + `navigating` (post-action router.push) into `loading`; Back to port → `PirateLinkButton`.
- `app/play/join/JoinClient.tsx` — Board the ship submit uses `useTransition` for nav.
- `app/play/lobby/FindCrewClient.tsx` — row Board/Spectate use new `loading` (replaces `'…'` text), other rows disabled via `anyJoining`; standalone Links → `PirateLinkButton`.
- `app/play/[code]/JoinGate.tsx` & `SpectateGate.tsx` — boarding/watch submit + Return to docks / Back to port use `loading`.
- `app/play/[code]/OnlineRoomClient.tsx` — adds shared `goToLobby` + `navLeaving` transition state, plumbs through `Lobby` / `Play` for Disembark / Leave / To port / Return to docks; Hoist the Colors!, Continue, Plunder / Bury It / Pass the Helm switch from `'…'` text to `loading` spinner.
- `app/not-found.tsx` — Sail Home → `PirateLinkButton`.

## Test plan

- [ ] Home → Set Sail shows spinner during route load
- [ ] Choose Game buttons all show spinner on tap
- [ ] Setup → Hoist the Colors! spins until `/play-local` mounts
- [ ] Online: New Room → Set Sail spins through createRoom + nav; Back to port spins on Link
- [ ] Join → Board the ship spins through to `/play/[code]`
- [ ] Find Crew row Board/Spectate spins; other rows go disabled during a join
- [ ] In-room: Disembark / Leave / Return to docks / Hoist Colors / Plunder / Bury It / Pass the Helm all spin
- [ ] 404 Sail Home spins
- [ ] Buttons keep the same width when spinner replaces label (no layout jump)
- [ ] Spinner reads as a status update to screen readers (`aria-busy`)