### PR TITLE
feat: skip continuation timer when all seated players continue

### DIFF
--- a/src/server/actions/continueIntoNextRound.ts
+++ b/src/server/actions/continueIntoNextRound.ts
@@ -14,6 +14,7 @@ import { broadcastRoomState } from '@/server/realtime/broadcast';
 import { fetchContinuation } from '@/server/continuation';
 import { toPublic } from '@/game/public';
 import { getSupabaseServer } from '@/server/supabase/server';
+import { finalizeContinuationCore } from '@/server/actions/finalizeContinuation';
 
 const InputSchema = z.object({
    code: z.string().trim().toUpperCase().length(4),
@@ -60,6 +61,19 @@ export async function continueIntoNextRound(
    const state = parseEngineState(game);
    const spectators = await fetchSpectators(db, game.id);
    const continuation = await fetchContinuation(db, game.id);
+
+   // Every seated player has opted in — skip the rest of the 60s wait
+   // and finalize now. Atomic claim inside finalizeContinuationCore makes
+   // concurrent last-clickers safe.
+   const allIn =
+      continuation !== null &&
+      continuation.seatedIds.length > 0 &&
+      continuation.continuedIds.length === continuation.seatedIds.length;
+   if (allIn) {
+      await finalizeContinuationCore(game.code, user.id, { force: true });
+      return { ok: true };
+   }
+
    await broadcastRoomState(game.code, {
       state: toPublic(state),
       spectators,

--- a/src/server/actions/finalizeContinuation.ts
+++ b/src/server/actions/finalizeContinuation.ts
@@ -57,6 +57,7 @@ export async function finalizeContinuation(
 export async function finalizeContinuationCore(
    roomCode: string,
    actorId: string,
+   opts: { force?: boolean } = {},
 ): Promise<FinalizeResult> {
    const game = await findCompletedOrActiveGame(roomCode);
    if (!game?.code) return { ok: false, error: 'Room not found' };
@@ -64,7 +65,7 @@ export async function finalizeContinuationCore(
    if (game.continuationFinalized) return { ok: true, finalized: false };
 
    const deadline = game.continuationDeadline;
-   if (deadline && deadline.getTime() > Date.now()) {
+   if (!opts.force && deadline && deadline.getTime() > Date.now()) {
       return { ok: false, error: 'Window still open' };
    }
 


### PR DESCRIPTION
## Summary
Skip the remainder of the 60s post-game continuation countdown when every seated player has clicked **Continue**. Previously the last clicker still had to wait out the timer with the others.

## Behaviour
- Every seated player opts in → finalize fires immediately on the last click. Fresh lobby restarts right away.
- One or more seats don't click → existing behaviour unchanged. Timer runs to deadline, hesitators get planked, survivors carry on.
- Solo player room: one click ends the wait instantly.

## Per-change breakdown
**`src/server/actions/finalizeContinuation.ts`**
- `finalizeContinuationCore` accepts a new `opts: { force?: boolean }`. When `force` is true the `"Window still open"` guard is skipped so early-finalize callers don't get rejected.
- Cron + client-deadline finalize paths pass nothing, so their behaviour is identical to before.

**`src/server/actions/continueIntoNextRound.ts`**
- After stamping `continued_at` and reading the fresh continuation state, check whether `continuedIds.length === seatedIds.length`.
- If so, call `finalizeContinuationCore(code, userId, { force: true })` and return — finalize emits its own `CONTINUATION_FINALIZED` broadcast, so the otherwise-redundant `CONTINUE_OPT_IN` broadcast is skipped on that path.
- Otherwise the original `CONTINUE_OPT_IN` broadcast still fires so other clients see the new opt-in.

## Race safety
Two players clicking Continue at the same instant could each see `allIn = true` and both call finalize. The atomic claim inside `finalizeContinuationCore` (`UPDATE games SET continuation_finalized = true WHERE continuation_finalized = false`) only succeeds once — the loser returns `{ ok: true, finalized: false }` and no-ops. No double-broadcast, no double-restart.

## Test plan
- [ ] 2-player room: both click Continue → lobby restarts without waiting the rest of the 60s.
- [ ] 3-player room, only 2 click → timer continues, hesitator planked at deadline.
- [ ] Solo room: single click skips the wait.
- [ ] Two players click within ~100ms of each other → only one CONTINUATION_FINALIZED broadcast lands, no duplicate restart.
- [ ] Cron-driven finalize at deadline still works for fully-hesitant rooms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)