### PR TITLE
feat: admin rooms page + delete actions

### DIFF
--- a/app/admin/rooms/RoomsTable.tsx
+++ b/app/admin/rooms/RoomsTable.tsx
@@ -1,0 +1,271 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { PirateButton } from '@/ui/pirate-button/PirateButton';
+import { deleteRoom, deleteAllRooms } from '@/server/actions/adminRooms';
+
+export type AdminRoomRow = {
+   id: string;
+   code: string | null;
+   isPublic: boolean;
+   status: 'lobby' | 'active' | 'complete' | 'abandoned';
+   deckVariant: string;
+   hostName: string;
+   seatedPlayers: number;
+   createdAt: string;
+   startedAt: string | null;
+   completedAt: string | null;
+};
+
+type Filter = 'open' | 'all';
+
+function age(iso: string): string {
+   const ms = Date.now() - new Date(iso).getTime();
+   const m = Math.floor(ms / 60_000);
+   if (m < 1) return 'just now';
+   if (m < 60) return `${m}m`;
+   const h = Math.floor(m / 60);
+   if (h < 24) return `${h}h`;
+   const d = Math.floor(h / 24);
+   return `${d}d`;
+}
+
+const STATUS_TINT: Record<AdminRoomRow['status'], string> = {
+   lobby: 'bg-[color:var(--color-teal-600)]/30 text-[color:var(--color-teal-200)]',
+   active: 'bg-[color:var(--color-gold-500)]/30 text-[color:var(--color-gold-200)]',
+   complete: 'bg-white/10 text-[color:var(--color-cream-200)]/70',
+   abandoned: 'bg-[color:var(--color-coral-600)]/30 text-[color:var(--color-coral-200)]',
+};
+
+export default function RoomsTable({ rows }: { rows: AdminRoomRow[] }) {
+   const router = useRouter();
+   const [filter, setFilter] = useState<Filter>('open');
+   const [busyId, setBusyId] = useState<string | null>(null);
+   const [bulkBusy, setBulkBusy] = useState(false);
+   const [error, setError] = useState<string | null>(null);
+   const [, startTransition] = useTransition();
+
+   const filtered = rows.filter((r) =>
+      filter === 'open' ? r.status === 'lobby' || r.status === 'active' : true,
+   );
+
+   async function onDelete(row: AdminRoomRow) {
+      const label = row.code ? `room ${row.code}` : `room ${row.id.slice(0, 8)}`;
+      if (!confirm(`Delete ${label}? This cascades all players, events, and join requests.`)) {
+         return;
+      }
+      setError(null);
+      setBusyId(row.id);
+      const res = await deleteRoom({ id: row.id });
+      setBusyId(null);
+      if (!res.ok) {
+         setError(res.error);
+         return;
+      }
+      startTransition(() => router.refresh());
+   }
+
+   async function onDeleteAll(scope: 'open' | 'all') {
+      const targets = scope === 'open' ? filtered.filter((r) => r.status === 'lobby' || r.status === 'active') : rows;
+      if (targets.length === 0) return;
+      const label =
+         scope === 'open'
+            ? `ALL ${targets.length} open (lobby/active) rooms`
+            : `EVERY room (${rows.length} total, including completed)`;
+      const ok = confirm(`Delete ${label}? This cannot be undone.`);
+      if (!ok) return;
+      const second = prompt(`Type DELETE to confirm deleting ${targets.length} room(s):`);
+      if (second !== 'DELETE') return;
+
+      setError(null);
+      setBulkBusy(true);
+      const res = await deleteAllRooms(
+         scope === 'open' ? { status: ['lobby', 'active'] } : {},
+      );
+      setBulkBusy(false);
+      if (!res.ok) {
+         setError(res.error);
+         return;
+      }
+      startTransition(() => router.refresh());
+   }
+
+   return (
+      <div className='space-y-4'>
+         <div className='flex flex-wrap items-center justify-between gap-3'>
+            <div className='inline-flex rounded-lg border border-white/10 p-1'>
+               <FilterTab active={filter === 'open'} onClick={() => setFilter('open')}>
+                  Open ({rows.filter((r) => r.status === 'lobby' || r.status === 'active').length})
+               </FilterTab>
+               <FilterTab active={filter === 'all'} onClick={() => setFilter('all')}>
+                  All ({rows.length})
+               </FilterTab>
+            </div>
+            <div className='flex gap-2'>
+               <PirateButton
+                  variant='danger'
+                  size='sm'
+                  loading={bulkBusy}
+                  disabled={filtered.length === 0}
+                  onClick={() => onDeleteAll('open')}
+               >
+                  Delete all open
+               </PirateButton>
+               <PirateButton
+                  variant='danger'
+                  size='sm'
+                  loading={bulkBusy}
+                  disabled={rows.length === 0}
+                  onClick={() => onDeleteAll('all')}
+               >
+                  Nuke everything
+               </PirateButton>
+            </div>
+         </div>
+
+         {error && (
+            <div className='rounded-lg border border-[color:var(--color-coral-500)]/50 bg-[color:var(--color-coral-600)]/15 px-3 py-2 text-sm text-[color:var(--color-coral-200)]'>
+               {error}
+            </div>
+         )}
+
+         <div className='max-h-[70vh] overflow-y-auto overflow-x-hidden rounded-xl border border-white/10 bg-black/20'>
+            <table className='w-full table-fixed border-collapse text-xs'>
+               <colgroup>
+                  <col className='w-[64px]' />
+                  <col className='w-[68px]' />
+                  <col className='w-[78px]' />
+                  <col className='w-[110px]' />
+                  <col className='w-[64px]' />
+                  <col className='w-[80px]' />
+                  <col className='w-[56px]' />
+                  <col className='w-[72px]' />
+               </colgroup>
+               <thead className='sticky top-0 z-10 bg-[color:var(--color-deep-800)]/95 backdrop-blur-sm'>
+                  <tr className='text-left text-[11px] uppercase tracking-wider text-[color:var(--color-cream-200)]/60'>
+                     <Th>Code</Th>
+                     <Th>Visibility</Th>
+                     <Th>Status</Th>
+                     <Th>Host</Th>
+                     <Th className='text-right'>Players</Th>
+                     <Th>Deck</Th>
+                     <Th>Age</Th>
+                     <Th className='text-right'>Actions</Th>
+                  </tr>
+               </thead>
+               <tbody>
+                  {filtered.length === 0 && (
+                     <tr>
+                        <td colSpan={8} className='px-2 py-5 text-center opacity-60'>
+                           No rooms.
+                        </td>
+                     </tr>
+                  )}
+                  {filtered.map((r) => (
+                     <tr
+                        key={r.id}
+                        className='border-t border-white/5 hover:bg-white/[0.03]'
+                     >
+                        <Td>
+                           <span className='font-mono text-sm tracking-wider'>
+                              {r.code ?? '—'}
+                           </span>
+                        </Td>
+                        <Td>
+                           <span
+                              title={r.isPublic ? 'Public' : 'Private'}
+                              className={
+                                 r.isPublic
+                                    ? 'inline-block rounded bg-[color:var(--color-teal-600)]/30 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-[color:var(--color-teal-200)]'
+                                    : 'inline-block rounded bg-white/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase text-[color:var(--color-cream-200)]/70'
+                              }
+                           >
+                              {r.isPublic ? 'public' : 'private'}
+                           </span>
+                        </Td>
+                        <Td>
+                           <span
+                              className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase ${STATUS_TINT[r.status]}`}
+                           >
+                              {r.status}
+                           </span>
+                        </Td>
+                        <Td className='truncate' title={r.hostName}>
+                           {r.hostName}
+                        </Td>
+                        <Td className='text-right tabular-nums'>{r.seatedPlayers}</Td>
+                        <Td className='truncate opacity-80' title={r.deckVariant}>
+                           {shortDeck(r.deckVariant)}
+                        </Td>
+                        <Td className='opacity-80'>{age(r.createdAt)}</Td>
+                        <Td className='text-right'>
+                           <button
+                              type='button'
+                              onClick={() => onDelete(r)}
+                              disabled={busyId === r.id}
+                              aria-label={`Delete room ${r.code ?? r.id}`}
+                              className='inline-flex h-7 items-center justify-center rounded-md border border-[color:var(--color-coral-500)]/50 bg-[color:var(--color-coral-600)]/20 px-2 text-[11px] font-bold uppercase tracking-wider text-[color:var(--color-coral-200)] transition-colors hover:bg-[color:var(--color-coral-600)]/40 disabled:opacity-50'
+                           >
+                              {busyId === r.id ? '…' : 'Del'}
+                           </button>
+                        </Td>
+                     </tr>
+                  ))}
+               </tbody>
+            </table>
+         </div>
+      </div>
+   );
+}
+
+function FilterTab({
+   active,
+   onClick,
+   children,
+}: {
+   active: boolean;
+   onClick: () => void;
+   children: React.ReactNode;
+}) {
+   return (
+      <button
+         type='button'
+         onClick={onClick}
+         className={`rounded-md px-3 py-1.5 text-sm font-medium tracking-wide transition-colors ${
+            active
+               ? 'bg-white/10 text-[color:var(--color-cream-100)]'
+               : 'text-[color:var(--color-cream-200)]/60 hover:text-[color:var(--color-cream-100)]'
+         }`}
+      >
+         {children}
+      </button>
+   );
+}
+
+function Th({ children, className = '' }: { children: React.ReactNode; className?: string }) {
+   return <th className={`px-2 py-1.5 font-semibold ${className}`}>{children}</th>;
+}
+
+function Td({
+   children,
+   className = '',
+   title,
+}: {
+   children: React.ReactNode;
+   className?: string;
+   title?: string;
+}) {
+   return (
+      <td className={`px-2 py-1 align-middle ${className}`} title={title}>
+         {children}
+      </td>
+   );
+}
+
+function shortDeck(v: string): string {
+   if (v === 'greedy') return 'greedy';
+   if (v === 'even_greedier') return 'greedier';
+   if (v === 'super_greedy') return 'super';
+   return v;
+}

--- a/app/admin/rooms/page.tsx
+++ b/app/admin/rooms/page.tsx
@@ -1,0 +1,74 @@
+import { notFound } from 'next/navigation';
+import { desc } from 'drizzle-orm';
+import { db } from '@/server/db/client';
+import { games } from '@/server/db/schema';
+import { getAdminUser } from '@/server/auth/admin';
+import RoomsTable, { type AdminRoomRow } from './RoomsTable';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdminRoomsPage() {
+   const admin = await getAdminUser();
+   if (!admin) notFound();
+
+   const rows = await db.query.games.findMany({
+      orderBy: [desc(games.createdAt)],
+   });
+
+   const seatedCounts = await db.query.gamePlayers.findMany({
+      columns: { gameId: true, leftAt: true },
+   });
+   const seatedByGame = new Map<string, number>();
+   for (const p of seatedCounts) {
+      if (p.leftAt !== null) continue;
+      seatedByGame.set(p.gameId, (seatedByGame.get(p.gameId) ?? 0) + 1);
+   }
+
+   const hostRows = await db.query.users.findMany({
+      columns: { id: true, displayName: true },
+   });
+   const hostNames = new Map(hostRows.map((u) => [u.id, u.displayName]));
+
+   const data: AdminRoomRow[] = rows.map((g) => ({
+      id: g.id,
+      code: g.code,
+      isPublic: g.isPublic,
+      status: g.status,
+      deckVariant: g.deckVariant,
+      hostName: hostNames.get(g.hostId) ?? '—',
+      seatedPlayers: seatedByGame.get(g.id) ?? 0,
+      createdAt:
+         typeof g.createdAt === 'string'
+            ? g.createdAt
+            : (g.createdAt as Date).toISOString(),
+      startedAt:
+         g.startedAt == null
+            ? null
+            : typeof g.startedAt === 'string'
+            ? g.startedAt
+            : (g.startedAt as Date).toISOString(),
+      completedAt:
+         g.completedAt == null
+            ? null
+            : typeof g.completedAt === 'string'
+            ? g.completedAt
+            : (g.completedAt as Date).toISOString(),
+   }));
+
+   return (
+      <main className='mx-auto w-full max-w-6xl px-4 py-8 text-[color:var(--color-cream-200)]'>
+         <header className='mb-6 flex flex-wrap items-baseline justify-between gap-3'>
+            <div>
+               <h1 className='font-display text-3xl uppercase tracking-wider'>
+                  Admin · Rooms
+               </h1>
+               <p className='mt-1 text-sm opacity-70'>
+                  Signed in as <span className='font-mono'>{admin.email}</span> ·{' '}
+                  {data.length} room{data.length === 1 ? '' : 's'}
+               </p>
+            </div>
+         </header>
+         <RoomsTable rows={data} />
+      </main>
+   );
+}

--- a/src/client/auth/useIsAdmin.ts
+++ b/src/client/auth/useIsAdmin.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useCurrentUser } from './useCurrentUser';
+
+function parseAdminEmails(): Set<string> {
+   const raw = process.env.NEXT_PUBLIC_ADMIN_EMAILS ?? '';
+   return new Set(
+      raw
+         .split(',')
+         .map((s) => s.trim().toLowerCase())
+         .filter(Boolean),
+   );
+}
+
+// Client-side UI gate only. Server actions and the /admin route still
+// enforce admin via ADMIN_EMAILS — flipping this in devtools just shows
+// the link, it does not grant access.
+export function useIsAdmin(): boolean {
+   const { user } = useCurrentUser();
+   return useMemo(() => {
+      const email = user?.email?.toLowerCase();
+      if (!email) return false;
+      return parseAdminEmails().has(email);
+   }, [user?.email]);
+}

--- a/src/server/actions/adminRooms.ts
+++ b/src/server/actions/adminRooms.ts
@@ -1,0 +1,65 @@
+'use server';
+
+import 'server-only';
+import { revalidatePath } from 'next/cache';
+import { eq, inArray } from 'drizzle-orm';
+import { z } from 'zod';
+import { db } from '@/server/db/client';
+import { games } from '@/server/db/schema';
+import { getAdminUser } from '@/server/auth/admin';
+
+export type AdminActionResult =
+   | { ok: true; deleted: number }
+   | { ok: false; error: string };
+
+const DeleteRoomInput = z.object({ id: z.string().uuid() });
+
+export async function deleteRoom(
+   input: z.input<typeof DeleteRoomInput>,
+): Promise<AdminActionResult> {
+   const admin = await getAdminUser();
+   if (!admin) return { ok: false, error: 'Not authorized' };
+
+   const parsed = DeleteRoomInput.safeParse(input);
+   if (!parsed.success) return { ok: false, error: 'Invalid input' };
+
+   try {
+      const deleted = await db
+         .delete(games)
+         .where(eq(games.id, parsed.data.id))
+         .returning({ id: games.id });
+      revalidatePath('/admin/rooms');
+      return { ok: true, deleted: deleted.length };
+   } catch (err) {
+      console.error('deleteRoom failed', err);
+      return { ok: false, error: 'Delete failed' };
+   }
+}
+
+const DeleteAllInput = z.object({
+   status: z.array(z.enum(['lobby', 'active', 'complete', 'abandoned'])).optional(),
+});
+
+export async function deleteAllRooms(
+   input: z.input<typeof DeleteAllInput> = {},
+): Promise<AdminActionResult> {
+   const admin = await getAdminUser();
+   if (!admin) return { ok: false, error: 'Not authorized' };
+
+   const parsed = DeleteAllInput.safeParse(input);
+   if (!parsed.success) return { ok: false, error: 'Invalid input' };
+
+   try {
+      const deleted = parsed.data.status?.length
+         ? await db
+              .delete(games)
+              .where(inArray(games.status, parsed.data.status))
+              .returning({ id: games.id })
+         : await db.delete(games).returning({ id: games.id });
+      revalidatePath('/admin/rooms');
+      return { ok: true, deleted: deleted.length };
+   } catch (err) {
+      console.error('deleteAllRooms failed', err);
+      return { ok: false, error: 'Delete failed' };
+   }
+}

--- a/src/server/auth/admin.ts
+++ b/src/server/auth/admin.ts
@@ -1,0 +1,25 @@
+import 'server-only';
+import { getSupabaseServer } from '@/server/supabase/server';
+
+function adminEmails(): Set<string> {
+   const raw = process.env.ADMIN_EMAILS ?? '';
+   return new Set(
+      raw
+         .split(',')
+         .map((s) => s.trim().toLowerCase())
+         .filter(Boolean),
+   );
+}
+
+export type AdminUser = { id: string; email: string };
+
+export async function getAdminUser(): Promise<AdminUser | null> {
+   const supabase = await getSupabaseServer();
+   const {
+      data: { user },
+   } = await supabase.auth.getUser();
+   if (!user?.email) return null;
+   const email = user.email.toLowerCase();
+   if (!adminEmails().has(email)) return null;
+   return { id: user.id, email };
+}

--- a/src/ui/top-nav/TopNav.tsx
+++ b/src/ui/top-nav/TopNav.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { emitProfileChanged, useCurrentUser } from '@/client/auth/useCurrentUser';
+import { useIsAdmin } from '@/client/auth/useIsAdmin';
 import { getSupabaseBrowser } from '@/client/supabase/browser';
 import { haptics } from '@/client/juice/haptics';
 import { AccountLinkModal } from '@/client/auth/AccountLinkModal';
@@ -107,6 +108,7 @@ function AccountMenu({
    isAnonymous: boolean;
 }) {
    const router = useRouter();
+   const isAdmin = useIsAdmin();
    const [open, setOpen] = useState(false);
    const [signingOut, setSigningOut] = useState(false);
    const [authModalOpen, setAuthModalOpen] = useState(false);
@@ -226,6 +228,23 @@ function AccountMenu({
                            </span>
                         </span>
                      </Link>
+                     {isAdmin && (
+                        <Link
+                           href='/admin/rooms'
+                           role='menuitem'
+                           data-testid='account-menu-admin'
+                           onClick={() => setOpen(false)}
+                           className='flex min-h-[48px] items-center gap-3 border-t border-[color:var(--color-surface-border)] px-4 text-sm font-semibold text-[color:var(--color-teal-200)] transition-colors hover:bg-[color:var(--color-teal-600)]/15'
+                        >
+                           <AdminIcon />
+                           <span>
+                              Admin · Rooms
+                              <span className='block text-xs font-normal text-[color:var(--color-cream-200)]/55'>
+                                 Inspect &amp; purge
+                              </span>
+                           </span>
+                        </Link>
+                     )}
                      <button
                         type='button'
                         role='menuitem'
@@ -279,6 +298,15 @@ function SignInIcon() {
          <path d='M10 4 H17 a2 2 0 0 1 2 2 v12 a2 2 0 0 1 -2 2 h-7' />
          <path d='M7 8 L3 12 L7 16' />
          <line x1='3' y1='12' x2='14' y2='12' />
+      </svg>
+   );
+}
+
+function AdminIcon() {
+   return (
+      <svg viewBox='0 0 24 24' className='h-5 w-5 shrink-0 text-[color:var(--color-teal-300)]' fill='none' stroke='currentColor' strokeWidth='1.8' strokeLinecap='round' strokeLinejoin='round' aria-hidden='true'>
+         <path d='M12 3 L20 6 V12 a8 8 0 0 1 -8 8 a8 8 0 0 1 -8 -8 V6 Z' />
+         <path d='M9 12 L11 14 L15 10' />
       </svg>
    );
 }


### PR DESCRIPTION
## Summary

Adds `/admin/rooms` — a server-rendered table of every game row (public + private, every status) with per-row and bulk delete. Useful for inspecting state during development and clearing test rooms.

## Per-change breakdown

**Admin gate**
- `src/server/auth/admin.ts` — `getAdminUser()` reads `ADMIN_EMAILS` (server-only, comma-separated). Returns `null` for non-admins.
- `src/client/auth/useIsAdmin.ts` — UI-only hook reading `NEXT_PUBLIC_ADMIN_EMAILS`. Server still enforces; the client hook only controls visibility of the menu link.

**Page**
- `app/admin/rooms/page.tsx` — RSC. Returns `notFound()` for non-admins (page existence hidden). Fetches all `games` rows + host display names + seated-player counts. Maps to `AdminRoomRow[]` for the client table.

**Client table**
- `app/admin/rooms/RoomsTable.tsx` — fixed-layout compact table, sticky header, `max-h-[70vh]` vertical scroll, no horizontal scroll. Filter tabs: Open (lobby/active) vs All (includes complete + abandoned). Per-row Delete (single confirm). Bulk *Delete all open* and *Nuke everything* with confirm + typed `DELETE` second confirm.

**Server actions**
- `src/server/actions/adminRooms.ts`
  - `deleteRoom({ id })` — admin-gated, Drizzle delete on `games` by id.
  - `deleteAllRooms({ status? })` — admin-gated, optional status filter. Defaults to deleting every row.
  - Cascade FKs on `games` clean up `game_players`, `game_events`, `game_spectators`, `game_join_requests` automatically.

**Nav**
- `src/ui/top-nav/TopNav.tsx` — adds an admin-only `Admin · Rooms` link to the account dropdown (signed-in branch only), gated by `useIsAdmin()`, teal accent + shield icon, separated by a top border.

## Setup

Two env vars need to be set in `.env.local` and on Vercel (Preview + Production):

```
ADMIN_EMAILS=paul@financial-cents.com
NEXT_PUBLIC_ADMIN_EMAILS=paul@financial-cents.com
```

`NEXT_PUBLIC_*` is only used for UI visibility. Server actions and the page route enforce `ADMIN_EMAILS` directly.

## Notes

- Drizzle bypasses RLS, so the server action enforces the admin check itself before any delete.
- Deleting an active room does **not** broadcast to connected players — their next action fails. Acceptable for an admin tool; can add a broadcast later if needed.
- The "Open" filter is the default (lobby + active). Toggle to "All" to see completed + abandoned rooms.

## Follow-up (next PR)

Open rooms accumulate up to ~24h because cron is daily but lobby threshold is 30 min, and abandoned/complete rows never get purged. Next branch will:
- Move cron to hourly
- Add `purge_old_games()` retention (preserves `user_stats`)
- Hard-delete solo-host empty lobbies on host leave

## Test plan

- [ ] Set `ADMIN_EMAILS` + `NEXT_PUBLIC_ADMIN_EMAILS` locally; sign in as that account → admin link appears in dropdown.
- [ ] Sign in as non-admin / anon → no admin link; visiting `/admin/rooms` returns 404.
- [ ] Create a few rooms, visit `/admin/rooms`, confirm rows appear with correct public/private + status.
- [ ] Per-row Delete → row vanishes after refresh; cascades remove `game_players`.
- [ ] Bulk *Delete all open* with typed `DELETE` confirm → only lobby/active rows removed.
- [ ] Vertical scroll works on long lists; no horizontal scroll at normal widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)