### PR TITLE
chore: bound games table growth via purge + immediate empty-room delete

### DIFF
--- a/app/api/cron/cleanup/route.ts
+++ b/app/api/cron/cleanup/route.ts
@@ -43,6 +43,11 @@ export async function GET(req: NextRequest) {
       )) as unknown as Array<{ prune_old_events: number }>;
       const prunedEvents = Number(pruneRows[0]?.prune_old_events ?? 0);
 
+      const purgeRows = (await db.execute<{ purge_old_games: number }>(
+         sql`select public.purge_old_games() as purge_old_games`,
+      )) as unknown as Array<{ purge_old_games: number }>;
+      const purgedGames = Number(purgeRows[0]?.purge_old_games ?? 0);
+
       const expiredRows = (await db.execute<ExpireRow>(
          sql`select * from public.expire_pending_join_requests()`,
       )) as unknown as ExpireRow[];
@@ -98,6 +103,7 @@ export async function GET(req: NextRequest) {
          abandonedLobbies: Number(abandon.abandoned_lobbies ?? 0),
          abandonedActive: Number(abandon.abandoned_active ?? 0),
          prunedEvents,
+         purgedGames,
          expiredKnocks: expiredRows.length,
          migratedHosts: migratedRows.length,
          finalizedContinuations,

--- a/src/server/actions/joinRoom.ts
+++ b/src/server/actions/joinRoom.ts
@@ -83,15 +83,14 @@ export async function leaveRoom(code: string): Promise<{ ok: boolean }> {
    }
 
    // Auto-close empty rooms. A lobby with 0 seated players is a ghost ship —
-   // no one can start it, and it just clutters the Find Crew feed.
+   // hard-delete so the games table stays bounded. Cascades clear any
+   // residual join requests / events. Stats already aggregated in
+   // user_stats on game completion, so abandoned/lobby rows lose nothing.
    const refreshed = await findGameByCode(code.toUpperCase());
    if (refreshed) {
       const state = parseEngineState(refreshed);
       if (state.players.length === 0) {
-         await db
-            .update(games)
-            .set({ status: 'abandoned' })
-            .where(eq(games.id, refreshed.id));
+         await db.delete(games).where(eq(games.id, refreshed.id));
          if (refreshed.isPublic && refreshed.code) {
             await broadcastLobbyEvent({ type: 'room_removed', code: refreshed.code });
          }

--- a/src/server/actions/leaveAsHost.ts
+++ b/src/server/actions/leaveAsHost.ts
@@ -80,20 +80,11 @@ export async function leaveAsHost(
       : engineOthers;
 
    if (others.length === 0) {
-      // Solo aboard — scuttle the ship. Marks the room abandoned outright
-      // (vs. relying on PLAYER_LEAVE leaving the engine empty) so ghost
-      // engine entries from disconnected players can't keep the room
-      // alive after the captain leaves. Also drops the host's gamePlayer
-      // row so it doesn't show up in Find Crew as orphaned.
-      await db.transaction(async (tx) => {
-         await tx
-            .delete(gamePlayers)
-            .where(and(eq(gamePlayers.gameId, game.id), eq(gamePlayers.userId, user.id)));
-         await tx
-            .update(games)
-            .set({ status: 'abandoned', hostLeftAt: new Date() })
-            .where(eq(games.id, game.id));
-      });
+      // Solo aboard — scuttle the ship completely. Hard-delete cascades
+      // game_players, events, and knocks so the games table stays bounded.
+      // Stats are aggregated separately in user_stats on game completion,
+      // so a never-finished lobby loses nothing on delete.
+      await db.delete(games).where(eq(games.id, game.id));
       if (game.isPublic && game.code) {
          await broadcastLobbyEvent({ type: 'room_removed', code: game.code });
       }

--- a/supabase/migrations/20260616000000_purge_old_games.sql
+++ b/supabase/migrations/20260616000000_purge_old_games.sql
@@ -1,0 +1,37 @@
+-- Hard-delete old terminal games to keep the table bounded.
+--
+-- Safe to delete the rows themselves because user_stats is a separate
+-- aggregate table — bumpUserStats() runs on the lobby/active → complete
+-- transition and persists lifetime totals independently of the games row.
+-- Abandoned/lobby rows never contributed to stats in the first place.
+--
+-- Cascades clear game_players, game_events, game_spectators, and
+-- game_join_requests via the FK ON DELETE CASCADE constraints.
+
+create or replace function public.purge_old_games()
+returns int
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+   v_deleted int := 0;
+begin
+   with deleted as (
+      delete from public.games
+         where (
+                  status = 'abandoned'
+                  and coalesce(completed_at, created_at) < now() - interval '7 days'
+               )
+            or (
+                  status = 'complete'
+                  and completed_at < now() - interval '30 days'
+               )
+         returning 1
+   )
+   select count(*)::int into v_deleted from deleted;
+   return v_deleted;
+end;
+$$;
+
+grant execute on function public.purge_old_games() to service_role;


### PR DESCRIPTION
## Summary

Caps unbounded growth of the `games` table without touching Vercel Hobby's daily-cron limit or adding any paid services. Open rooms now disappear the moment they go empty, and terminal rooms (abandoned/complete) get hard-deleted after a retention window.

## Why

Before this PR:
- `abandon_stale_games()` only flipped `status` — rows lived forever.
- `leaveRoom` + `leaveAsHost` set empty lobbies to `status='abandoned'` rather than deleting them.
- Daily cron + 30-min lobby threshold meant abandoned rows accumulated indefinitely.

After ~30 minutes of admin-table testing yesterday we had **91** open lobbies sitting around with no real activity. Not breaking anything, but unbounded.

## Per-change breakdown

**New migration: `supabase/migrations/20260616000000_purge_old_games.sql`**
- Adds `purge_old_games()` SECURITY DEFINER function.
- Hard-deletes:
  - `status = 'abandoned'` and `coalesce(completed_at, created_at) < now() - interval '7 days'`
  - `status = 'complete'` and `completed_at < now() - interval '30 days'`
- Cascades clear `game_players`, `game_events`, `game_spectators`, `game_join_requests` via existing `ON DELETE CASCADE` FKs.
- `grant execute ... to service_role`.

**Cron route: `app/api/cron/cleanup/route.ts`**
- Calls `purge_old_games()` alongside existing `abandon_stale_games`, `prune_old_events`, knock expiry, orphan-host migration, and continuation finalize.
- Surfaces `purgedGames` in the response payload.

**`src/server/actions/joinRoom.ts` → `leaveRoom`**
- When the last seated player leaves a lobby, hard-delete the `games` row instead of setting status to `abandoned`. Still broadcasts `room_removed` for public rooms.

**`src/server/actions/leaveAsHost.ts` → solo-host exit**
- When host leaves with no other seated players, hard-delete the `games` row instead of stamping `host_left_at` and setting status to `abandoned`. Cascades drop the host's `game_players` row automatically, so the explicit transaction is no longer needed.

## user_stats is preserved

`bumpUserStats` runs on the `lobby/active → complete` transition (`src/server/game-room.ts:202`) and writes lifetime totals into the separate `user_stats` table. That table has FK only on `users`, so deleting a `games` row never cascades into stats. Specifically:
- Lobby/abandoned rows never contributed stats → safe to delete.
- Complete rows have already aggregated stats by the time the 30-day purge window hits → safe to delete.

## Cost impact

None. Stays on:
- Vercel Hobby — cron remains daily, no new endpoints.
- Supabase Free — one new function, no new tables, no new indexes.

## Test plan

- [ ] Apply migration locally: `pnpm db:push` (or whatever the project flow is).
- [ ] Create a public lobby, join from a second tab, leave from each tab — confirm the room is gone from `/admin/rooms` after the second leave (not just marked `abandoned`).
- [ ] Create a lobby as host alone, host leaves — confirm the row is gone (not marked `abandoned`).
- [ ] Manually call the cron route locally: `curl -H "Authorization: Bearer $CRON_SECRET" http://localhost:3000/api/cron/cleanup` — response should include `purgedGames`.
- [ ] Seed an abandoned row with `created_at` > 7 days ago and re-run cron — confirm purged.
- [ ] Smoke: existing `leaveRoom` / `leaveAsHost` flows still work for multi-player lobbies (no regressions in pass-the-wheel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)