### PR TITLE
feat: mirror email to public.users + account settings (change email / password / reset)

### DIFF
--- a/.claude/docs/database.md
+++ b/.claude/docs/database.md
@@ -21,6 +21,7 @@ Supabase Auth manages `auth.users`. We add a profile table; the `handle_new_user
 |---|---|---|
 | `id` | `uuid` PK | FK → `auth.users.id`. Same id for anon and email users. |
 | `display_name` | `text` not null | Player's chosen name. Defaults to `Crewmate` until the name prompt completes. |
+| `email` | `text` nullable | Mirror of `auth.users.email`. Populated by the `handle_new_user` insert trigger and the `sync_user_email` update trigger so anon→email upgrades stay in sync. Null for anonymous users. Protected by the `users_self_read` RLS policy. |
 | `is_anonymous` | `boolean` default true | Flipped to false when `markAccountClaimed` runs after an email upgrade. |
 | `created_at` | `timestamptz` default now() | |
 

--- a/.claude/docs/supabase-setup.md
+++ b/.claude/docs/supabase-setup.md
@@ -57,7 +57,6 @@ The `mv` dance is required because Supabase auto-applies migrations during `star
 | API | http://127.0.0.1:54321 |
 | Postgres | postgres://postgres:postgres@127.0.0.1:54322/postgres |
 | Mailpit (catches confirmation emails) | http://127.0.0.1:54324 |
-| Drizzle Studio | run `npm run db:studio` |
 
 When you change `schema.ts`:
 ```bash
@@ -138,8 +137,10 @@ Vercel Hobby tier caps cron at once per day. Upgrade to Pro if you want more fre
 1. Dashboard → **Authentication** → **Providers** → scroll to **Anonymous Sign-ins** → toggle ON → **Save**. Confirm the page refreshes with the toggle still ON — it occasionally fails to persist on first save.
 2. **Authentication** → **URL Configuration**:
    - **Site URL** = production domain (e.g. `https://www.greedypirate.com`).
-   - **Redirect URLs** = add `https://www.greedypirate.com/**`, `https://greedypirate.com/**`, and `http://localhost:3000/**` (for local dev).
-   - Without this, email-verify links default to `localhost:3000`.
+   - **Redirect URLs** = add `https://www.greedypirate.com/**`, `https://greedypirate.com/**`, `https://*.vercel.app/**` (preview deploys), and `http://localhost:3000/**` (for local dev).
+   - Email-change, password-reset, and signup-confirmation links all redirect through `/auth/callback`. Without these entries the links fall back to `localhost:3000` and break in prod.
+3. **Authentication** → **Email**:
+   - Enable **Secure email change** (double-confirm) — sends the change link to both the old AND new address. Recommended; without it a hijacked active session can silently steal the account.
 
 ### Step 3 — Grab the keys
 
@@ -184,6 +185,8 @@ Migrations run automatically on every Vercel build via the `vercel-build` script
 | `SUPABASE_DB_PASSWORD` | raw DB password | script URL-encodes for you — paste it raw |
 | `SUPABASE_DB_HOST` | e.g. `aws-0-us-west-1.pooler.supabase.com` | session-pooler host (port 5432) |
 | `SUPABASE_PROJECT_REF` | e.g. `fyuasgpjrphxrituofsm` | the project ref slug |
+| `ADMIN_EMAILS` | comma-separated emails | server-side gate for `/admin/rooms` + admin actions; leave empty to lock everyone out |
+| `NEXT_PUBLIC_ADMIN_EMAILS` | same value as `ADMIN_EMAILS` | UI-only mirror; shows the admin link in the account dropdown |
 
 Add via dashboard or CLI:
 

--- a/README.md
+++ b/README.md
@@ -68,13 +68,12 @@ The first time you load the app you'll be silently signed in as an anonymous use
 
 ### Companion URLs (local)
 
-| What                                | URL                     |
-| ----------------------------------- | ----------------------- |
-| App                                 | http://localhost:3000   |
-| Supabase Studio (DB GUI)            | http://127.0.0.1:54323  |
-| Supabase API                        | http://127.0.0.1:54321  |
-| Mailpit (catches auth emails)       | http://127.0.0.1:54324  |
-| Drizzle Studio (alternative DB GUI) | run `npm run db:studio` |
+| What                          | URL                    |
+| ----------------------------- | ---------------------- |
+| App                           | http://localhost:3000  |
+| Supabase Studio (DB GUI)      | http://127.0.0.1:54323 |
+| Supabase API                  | http://127.0.0.1:54321 |
+| Mailpit (catches auth emails) | http://127.0.0.1:54324 |
 
 ### Stopping
 
@@ -105,8 +104,7 @@ npm run supabase:reset         # wipes the local DB and re-runs all migrations
 | `npm run test:run`       | Vitest single run. CI-friendly.                                                                          |
 | `npm run db:generate`    | Generate a new Drizzle migration after editing `schema.ts`.                                              |
 | `npm run db:migrate`     | Apply Drizzle migrations to the current `DATABASE_URL`.                                                  |
-| `npm run db:push`        | Push schema without writing a migration file (dev only).                                                 |
-| `npm run db:studio`      | Open Drizzle Studio (web GUI).                                                                           |
+| `npm run db:migrate:all` | Apply Drizzle migrations + push Supabase SQL migrations (RLS, triggers, functions) to the local DB.      |
 | `npm run supabase:start` | Start the local Supabase stack (Docker).                                                                 |
 | `npm run supabase:stop`  | Stop the local Supabase stack.                                                                           |
 | `npm run supabase:reset` | Wipe the local DB and re-run all migrations.                                                             |

--- a/app/admin/rooms/RoomsTable.tsx
+++ b/app/admin/rooms/RoomsTable.tsx
@@ -12,6 +12,7 @@ export type AdminRoomRow = {
    status: 'lobby' | 'active' | 'complete' | 'abandoned';
    deckVariant: string;
    hostName: string;
+   hostEmail: string | null;
    seatedPlayers: number;
    createdAt: string;
    startedAt: string | null;
@@ -136,7 +137,7 @@ export default function RoomsTable({ rows }: { rows: AdminRoomRow[] }) {
                   <col className='w-[64px]' />
                   <col className='w-[68px]' />
                   <col className='w-[78px]' />
-                  <col className='w-[110px]' />
+                  <col className='w-[180px]' />
                   <col className='w-[64px]' />
                   <col className='w-[80px]' />
                   <col className='w-[56px]' />
@@ -191,8 +192,11 @@ export default function RoomsTable({ rows }: { rows: AdminRoomRow[] }) {
                               {r.status}
                            </span>
                         </Td>
-                        <Td className='truncate' title={r.hostName}>
-                           {r.hostName}
+                        <Td title={r.hostEmail ? `${r.hostName} · ${r.hostEmail}` : r.hostName}>
+                           <div className='truncate'>{r.hostName}</div>
+                           <div className='truncate text-[10px] opacity-60'>
+                              {r.hostEmail ?? 'anon'}
+                           </div>
                         </Td>
                         <Td className='text-right tabular-nums'>{r.seatedPlayers}</Td>
                         <Td className='truncate opacity-80' title={r.deckVariant}>

--- a/app/admin/rooms/page.tsx
+++ b/app/admin/rooms/page.tsx
@@ -25,9 +25,11 @@ export default async function AdminRoomsPage() {
    }
 
    const hostRows = await db.query.users.findMany({
-      columns: { id: true, displayName: true },
+      columns: { id: true, displayName: true, email: true },
    });
-   const hostNames = new Map(hostRows.map((u) => [u.id, u.displayName]));
+   const hosts = new Map(
+      hostRows.map((u) => [u.id, { name: u.displayName, email: u.email }]),
+   );
 
    const data: AdminRoomRow[] = rows.map((g) => ({
       id: g.id,
@@ -35,7 +37,8 @@ export default async function AdminRoomsPage() {
       isPublic: g.isPublic,
       status: g.status,
       deckVariant: g.deckVariant,
-      hostName: hostNames.get(g.hostId) ?? '—',
+      hostName: hosts.get(g.hostId)?.name ?? '—',
+      hostEmail: hosts.get(g.hostId)?.email ?? null,
       seatedPlayers: seatedByGame.get(g.id) ?? 0,
       createdAt:
          typeof g.createdAt === 'string'

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,45 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { getSupabaseServer } from '@/server/supabase/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Auth callback for Supabase email links:
+ *   - email change confirmation
+ *   - password recovery
+ *   - email signup confirmation
+ *
+ * Supabase appends `?code=<pkce>` (and sometimes `?type=recovery|email_change|signup`)
+ * to the redirect URL. We exchange the code for a session here, then
+ * route the user to the appropriate next page.
+ */
+export async function GET(req: NextRequest) {
+   const { searchParams, origin } = new URL(req.url);
+   const code = searchParams.get('code');
+   const type = searchParams.get('type');
+   const next = searchParams.get('next');
+
+   if (!code) {
+      return NextResponse.redirect(`${origin}/profile?auth=missing-code`);
+   }
+
+   const supabase = await getSupabaseServer();
+   const { error } = await supabase.auth.exchangeCodeForSession(code);
+   if (error) {
+      console.error('[auth/callback] exchange failed', error);
+      return NextResponse.redirect(`${origin}/profile?auth=failed`);
+   }
+
+   // Password recovery links land here; the session is now scoped for a
+   // password change. Bounce to /auth/reset which renders the form.
+   if (type === 'recovery') {
+      return NextResponse.redirect(`${origin}/auth/reset`);
+   }
+
+   if (type === 'email_change') {
+      return NextResponse.redirect(`${origin}/profile?auth=email-changed`);
+   }
+
+   return NextResponse.redirect(`${origin}${next ?? '/profile'}`);
+}

--- a/app/auth/reset/ResetPasswordForm.tsx
+++ b/app/auth/reset/ResetPasswordForm.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowser } from '@/client/supabase/browser';
+import { PirateButton } from '@/ui/pirate-button/PirateButton';
+
+const MIN_PASSWORD = 8;
+
+export function ResetPasswordForm() {
+   const router = useRouter();
+   const [password, setPassword] = useState('');
+   const [confirm, setConfirm] = useState('');
+   const [error, setError] = useState<string | null>(null);
+   const [submitting, setSubmitting] = useState(false);
+
+   const submit = async (e: React.FormEvent) => {
+      e.preventDefault();
+      setError(null);
+
+      if (password.length < MIN_PASSWORD) {
+         setError(`Password must be at least ${MIN_PASSWORD} characters`);
+         return;
+      }
+      if (password !== confirm) {
+         setError('Passwords do not match');
+         return;
+      }
+
+      setSubmitting(true);
+      const supabase = getSupabaseBrowser();
+      const { error: updateError } = await supabase.auth.updateUser({ password });
+      setSubmitting(false);
+      if (updateError) {
+         setError(updateError.message);
+         return;
+      }
+      router.push('/profile?auth=password-reset');
+      router.refresh();
+   };
+
+   return (
+      <form onSubmit={submit} className='flex flex-col gap-3'>
+         <label className='flex flex-col gap-1 text-sm'>
+            New password
+            <input
+               type='password'
+               autoComplete='new-password'
+               value={password}
+               onChange={(e) => setPassword(e.target.value)}
+               className='min-h-[44px] rounded-md border border-white/15 bg-black/30 px-3 text-base'
+               required
+            />
+         </label>
+         <label className='flex flex-col gap-1 text-sm'>
+            Confirm new password
+            <input
+               type='password'
+               autoComplete='new-password'
+               value={confirm}
+               onChange={(e) => setConfirm(e.target.value)}
+               className='min-h-[44px] rounded-md border border-white/15 bg-black/30 px-3 text-base'
+               required
+            />
+         </label>
+         {error && (
+            <p className='text-sm text-[color:var(--color-coral-300)]'>{error}</p>
+         )}
+         <PirateButton type='submit' loading={submitting} fullWidth>
+            Set new password
+         </PirateButton>
+      </form>
+   );
+}

--- a/app/auth/reset/page.tsx
+++ b/app/auth/reset/page.tsx
@@ -1,0 +1,31 @@
+import { redirect } from 'next/navigation';
+import { getSupabaseServer } from '@/server/supabase/server';
+import { ResetPasswordForm } from './ResetPasswordForm';
+
+export const dynamic = 'force-dynamic';
+
+export default async function ResetPasswordPage() {
+   const supabase = await getSupabaseServer();
+   const {
+      data: { user },
+   } = await supabase.auth.getUser();
+
+   // Recovery link lands here via /auth/callback?type=recovery, which
+   // exchanges the PKCE code and gives us a recovery-scoped session.
+   // Without that session there is nothing to do here — punt to home.
+   if (!user) redirect('/');
+
+   return (
+      <main className='mx-auto flex w-full max-w-md flex-1 flex-col justify-center gap-6 px-5 py-10 text-[color:var(--color-cream-200)]'>
+         <header>
+            <h1 className='font-display text-3xl uppercase tracking-wider text-[color:var(--color-gold-200)]'>
+               Set a new password
+            </h1>
+            <p className='mt-2 text-sm opacity-75'>
+               Resetting for <span className='font-mono'>{user.email}</span>.
+            </p>
+         </header>
+         <ResetPasswordForm />
+      </main>
+   );
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -5,11 +5,31 @@ import { games, userStats, users } from '@/server/db/schema';
 import { getSupabaseServer } from '@/server/supabase/server';
 import { PiratePanel } from '@/ui/pirate-panel/PiratePanel';
 import { AccountUpgrade } from '@/client/auth/AccountUpgrade';
+import { AccountSettings } from '@/client/auth/AccountSettings';
 import { ProfileNameHeader } from './ProfileNameHeader';
 
 export const dynamic = 'force-dynamic';
 
-export default async function ProfilePage() {
+const AUTH_BANNERS: Record<string, { tone: 'info' | 'success' | 'error'; text: string }> = {
+   'email-changed': {
+      tone: 'success',
+      text: 'Email change confirmed.',
+   },
+   'password-reset': {
+      tone: 'success',
+      text: 'Password reset. You are signed in.',
+   },
+   failed: { tone: 'error', text: 'Auth link expired or invalid. Try again.' },
+   'missing-code': { tone: 'error', text: 'Auth link was incomplete.' },
+};
+
+export default async function ProfilePage({
+   searchParams,
+}: {
+   searchParams: Promise<{ auth?: string }>;
+}) {
+   const params = await searchParams;
+   const banner = params.auth ? AUTH_BANNERS[params.auth] : undefined;
    const supabase = await getSupabaseServer();
    const {
       data: { user },
@@ -77,12 +97,32 @@ export default async function ProfilePage() {
 
    return (
       <main className='flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto px-5 py-6 pb-[max(env(safe-area-inset-bottom),1.5rem)] sm:py-10'>
+         {banner && (
+            <div
+               className={
+                  banner.tone === 'success'
+                     ? 'rounded-lg border border-[color:var(--color-teal-500)]/40 bg-[color:var(--color-teal-600)]/15 px-3 py-2 text-sm text-[color:var(--color-teal-200)]'
+                     : banner.tone === 'error'
+                     ? 'rounded-lg border border-[color:var(--color-coral-500)]/50 bg-[color:var(--color-coral-600)]/15 px-3 py-2 text-sm text-[color:var(--color-coral-200)]'
+                     : 'rounded-lg border border-white/15 bg-white/5 px-3 py-2 text-sm'
+               }
+            >
+               {banner.text}
+            </div>
+         )}
+
          <ProfileNameHeader
             initialName={displayName}
             isAnonymous={false}
             userIdShort={user.id.slice(0, 8)}
             size='lg'
          />
+
+         {profile?.email && (
+            <p className='-mt-3 text-center text-sm text-[color:var(--color-cream-200)]/65'>
+               <span className='font-mono'>{profile.email}</span>
+            </p>
+         )}
 
          <section className='grid grid-cols-2 gap-3'>
             <Stat label='Voyages' value={gamesPlayed} tone='teal' />
@@ -141,6 +181,8 @@ export default async function ProfilePage() {
                </ul>
             )}
          </section>
+
+         {profile?.email && <AccountSettings currentEmail={profile.email} />}
       </main>
    );
 }

--- a/package.json
+++ b/package.json
@@ -16,12 +16,9 @@
       "typecheck": "tsc --noEmit",
       "db:generate": "drizzle-kit generate",
       "db:migrate": "drizzle-kit migrate",
-      "db:push": "drizzle-kit push",
-      "db:studio": "drizzle-kit studio",
       "supabase:start": "supabase start",
       "supabase:stop": "supabase stop",
       "supabase:reset": "supabase db reset",
-      "supabase:push": "supabase db push --local",
       "db:migrate:all": "drizzle-kit migrate && supabase db push --local"
    },
    "dependencies": {

--- a/src/client/auth/AccountLinkModal.tsx
+++ b/src/client/auth/AccountLinkModal.tsx
@@ -41,6 +41,29 @@ export function AccountLinkModal({ open, onClose, initialMode = 'signup' }: Prop
    const [error, setError] = useState<string | null>(null);
    const [info, setInfo] = useState<string | null>(null);
    const [submitting, setSubmitting] = useState(false);
+   const [sendingReset, setSendingReset] = useState(false);
+
+   const sendReset = async () => {
+      setError(null);
+      setInfo(null);
+      const trimmed = email.trim().toLowerCase();
+      if (!trimmed.includes('@')) {
+         setError('Enter yer email above first, then tap "Forgot password?".');
+         return;
+      }
+      setSendingReset(true);
+      const supabase = getSupabaseBrowser();
+      const origin = typeof window !== 'undefined' ? window.location.origin : '';
+      const { error: resetError } = await supabase.auth.resetPasswordForEmail(trimmed, {
+         redirectTo: `${origin}/auth/callback?type=recovery`,
+      });
+      setSendingReset(false);
+      if (resetError) {
+         setError(resetError.message);
+         return;
+      }
+      setInfo(`Password reset link sent to ${trimmed}. Check yer inbox.`);
+   };
 
    useEffect(() => {
       if (open) {
@@ -236,6 +259,17 @@ export function AccountLinkModal({ open, onClose, initialMode = 'signup' }: Prop
                   className='input-pirate min-h-[48px] text-base'
                />
             </label>
+
+            {!isSignup && (
+               <button
+                  type='button'
+                  onClick={sendReset}
+                  disabled={sendingReset}
+                  className='self-start text-xs font-semibold uppercase tracking-wider text-[color:var(--color-gold-300)] hover:text-[color:var(--color-gold-200)] disabled:opacity-60'
+               >
+                  {sendingReset ? 'Sending…' : 'Forgot password?'}
+               </button>
+            )}
 
             {error && <p className='text-sm text-[color:var(--color-coral-400)]'>{error}</p>}
             {info && <p className='text-sm text-[color:var(--color-teal-300)]'>{info}</p>}

--- a/src/client/auth/AccountSettings.tsx
+++ b/src/client/auth/AccountSettings.tsx
@@ -1,0 +1,296 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSupabaseBrowser } from '@/client/supabase/browser';
+import { emitProfileChanged } from '@/client/auth/useCurrentUser';
+import { PirateButton } from '@/ui/pirate-button/PirateButton';
+import { PiratePanel } from '@/ui/pirate-panel/PiratePanel';
+
+const MIN_PASSWORD = 8;
+
+interface Props {
+   currentEmail: string;
+}
+
+/**
+ * Account settings panels on /profile for claimed (non-anon) users.
+ *  - Change email: reauth with current password, then updateUser({email}).
+ *    Supabase sends a confirmation link to the new address (and the old
+ *    one if "Secure email change" is enabled). The link routes through
+ *    /auth/callback which exchanges the PKCE code; our sync_user_email
+ *    trigger then mirrors the new address into public.users.
+ *  - Change password: reauth with current password, then updateUser({password}).
+ *    Update takes effect immediately, no email round-trip.
+ */
+export function AccountSettings({ currentEmail }: Props) {
+   return (
+      <section className='flex flex-col gap-4'>
+         <h2 className='pirate-display text-2xl text-[color:var(--color-gold-200)]'>
+            Account settings
+         </h2>
+         <ChangeEmailPanel currentEmail={currentEmail} />
+         <ChangePasswordPanel currentEmail={currentEmail} />
+      </section>
+   );
+}
+
+function ChangeEmailPanel({ currentEmail }: { currentEmail: string }) {
+   const router = useRouter();
+   const [open, setOpen] = useState(false);
+   const [password, setPassword] = useState('');
+   const [newEmail, setNewEmail] = useState('');
+   const [error, setError] = useState<string | null>(null);
+   const [info, setInfo] = useState<string | null>(null);
+   const [submitting, setSubmitting] = useState(false);
+
+   const reset = () => {
+      setPassword('');
+      setNewEmail('');
+      setError(null);
+      setInfo(null);
+   };
+
+   const submit = async (e: React.FormEvent) => {
+      e.preventDefault();
+      setError(null);
+      setInfo(null);
+
+      const trimmed = newEmail.trim().toLowerCase();
+      if (!trimmed.includes('@')) {
+         setError('Enter a valid email');
+         return;
+      }
+      if (trimmed === currentEmail.toLowerCase()) {
+         setError('That is already your email');
+         return;
+      }
+
+      setSubmitting(true);
+      const supabase = getSupabaseBrowser();
+
+      // Reauth — proves the caller knows the current password before we
+      // mutate identity. Without this step, a hijacked session could
+      // silently steal the account by changing the email.
+      const reauth = await supabase.auth.signInWithPassword({
+         email: currentEmail,
+         password,
+      });
+      if (reauth.error) {
+         setSubmitting(false);
+         setError('Current password is incorrect');
+         return;
+      }
+
+      const origin = typeof window !== 'undefined' ? window.location.origin : '';
+      const { error: updateError } = await supabase.auth.updateUser(
+         { email: trimmed },
+         { emailRedirectTo: `${origin}/auth/callback?type=email_change` },
+      );
+      setSubmitting(false);
+
+      if (updateError) {
+         setError(updateError.message);
+         return;
+      }
+
+      setInfo(
+         `Confirmation link sent to ${trimmed}. The change takes effect after you click it (and the link sent to your current address, if double-confirm is on).`,
+      );
+      setPassword('');
+      setNewEmail('');
+      router.refresh();
+   };
+
+   return (
+      <PiratePanel variant='deep' className='flex flex-col gap-3 p-4'>
+         <div className='flex items-center justify-between gap-3'>
+            <div className='min-w-0'>
+               <h3 className='text-sm font-semibold uppercase tracking-wider text-[color:var(--color-cream-200)]/80'>
+                  Email
+               </h3>
+               <p className='truncate font-mono text-base'>{currentEmail}</p>
+            </div>
+            <PirateButton
+               variant='tertiary'
+               size='sm'
+               onClick={() => {
+                  if (open) reset();
+                  setOpen((o) => !o);
+               }}
+            >
+               {open ? 'Cancel' : 'Change'}
+            </PirateButton>
+         </div>
+         {open && (
+            <form onSubmit={submit} className='flex flex-col gap-3 border-t border-white/10 pt-3'>
+               <label className='flex flex-col gap-1 text-sm'>
+                  Current password
+                  <input
+                     type='password'
+                     autoComplete='current-password'
+                     value={password}
+                     onChange={(e) => setPassword(e.target.value)}
+                     className='min-h-[44px] rounded-md border border-white/15 bg-black/30 px-3 text-base'
+                     required
+                  />
+               </label>
+               <label className='flex flex-col gap-1 text-sm'>
+                  New email
+                  <input
+                     type='email'
+                     autoComplete='email'
+                     value={newEmail}
+                     onChange={(e) => setNewEmail(e.target.value)}
+                     className='min-h-[44px] rounded-md border border-white/15 bg-black/30 px-3 text-base'
+                     required
+                  />
+               </label>
+               {error && (
+                  <p className='text-sm text-[color:var(--color-coral-300)]'>{error}</p>
+               )}
+               {info && (
+                  <p className='text-sm text-[color:var(--color-teal-200)]'>{info}</p>
+               )}
+               <PirateButton type='submit' loading={submitting} fullWidth size='sm'>
+                  Send confirmation email
+               </PirateButton>
+            </form>
+         )}
+      </PiratePanel>
+   );
+}
+
+function ChangePasswordPanel({ currentEmail }: { currentEmail: string }) {
+   const [open, setOpen] = useState(false);
+   const [current, setCurrent] = useState('');
+   const [next, setNext] = useState('');
+   const [confirm, setConfirm] = useState('');
+   const [error, setError] = useState<string | null>(null);
+   const [info, setInfo] = useState<string | null>(null);
+   const [submitting, setSubmitting] = useState(false);
+
+   const reset = () => {
+      setCurrent('');
+      setNext('');
+      setConfirm('');
+      setError(null);
+      setInfo(null);
+   };
+
+   const submit = async (e: React.FormEvent) => {
+      e.preventDefault();
+      setError(null);
+      setInfo(null);
+
+      if (next.length < MIN_PASSWORD) {
+         setError(`Password must be at least ${MIN_PASSWORD} characters`);
+         return;
+      }
+      if (next !== confirm) {
+         setError('New passwords do not match');
+         return;
+      }
+      if (next === current) {
+         setError('New password must be different');
+         return;
+      }
+
+      setSubmitting(true);
+      const supabase = getSupabaseBrowser();
+      const reauth = await supabase.auth.signInWithPassword({
+         email: currentEmail,
+         password: current,
+      });
+      if (reauth.error) {
+         setSubmitting(false);
+         setError('Current password is incorrect');
+         return;
+      }
+
+      const { error: updateError } = await supabase.auth.updateUser({ password: next });
+      setSubmitting(false);
+      if (updateError) {
+         setError(updateError.message);
+         return;
+      }
+
+      setInfo('Password updated.');
+      emitProfileChanged();
+      reset();
+      setOpen(false);
+   };
+
+   return (
+      <PiratePanel variant='deep' className='flex flex-col gap-3 p-4'>
+         <div className='flex items-center justify-between gap-3'>
+            <div className='min-w-0'>
+               <h3 className='text-sm font-semibold uppercase tracking-wider text-[color:var(--color-cream-200)]/80'>
+                  Password
+               </h3>
+               <p className='text-sm text-[color:var(--color-cream-200)]/55'>
+                  Change your sign-in password.
+               </p>
+            </div>
+            <PirateButton
+               variant='tertiary'
+               size='sm'
+               onClick={() => {
+                  if (open) reset();
+                  setOpen((o) => !o);
+               }}
+            >
+               {open ? 'Cancel' : 'Change'}
+            </PirateButton>
+         </div>
+         {!open && info && (
+            <p className='border-t border-white/10 pt-3 text-sm text-[color:var(--color-teal-200)]'>
+               {info}
+            </p>
+         )}
+         {open && (
+            <form onSubmit={submit} className='flex flex-col gap-3 border-t border-white/10 pt-3'>
+               <label className='flex flex-col gap-1 text-sm'>
+                  Current password
+                  <input
+                     type='password'
+                     autoComplete='current-password'
+                     value={current}
+                     onChange={(e) => setCurrent(e.target.value)}
+                     className='min-h-[44px] rounded-md border border-white/15 bg-black/30 px-3 text-base'
+                     required
+                  />
+               </label>
+               <label className='flex flex-col gap-1 text-sm'>
+                  New password
+                  <input
+                     type='password'
+                     autoComplete='new-password'
+                     value={next}
+                     onChange={(e) => setNext(e.target.value)}
+                     className='min-h-[44px] rounded-md border border-white/15 bg-black/30 px-3 text-base'
+                     required
+                  />
+               </label>
+               <label className='flex flex-col gap-1 text-sm'>
+                  Confirm new password
+                  <input
+                     type='password'
+                     autoComplete='new-password'
+                     value={confirm}
+                     onChange={(e) => setConfirm(e.target.value)}
+                     className='min-h-[44px] rounded-md border border-white/15 bg-black/30 px-3 text-base'
+                     required
+                  />
+               </label>
+               {error && (
+                  <p className='text-sm text-[color:var(--color-coral-300)]'>{error}</p>
+               )}
+               <PirateButton type='submit' loading={submitting} fullWidth size='sm'>
+                  Update password
+               </PirateButton>
+            </form>
+         )}
+      </PiratePanel>
+   );
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -25,6 +25,7 @@ export const users = pgTable('users', {
       .primaryKey()
       .references(() => authUsers.id, { onDelete: 'cascade' }),
    displayName: text('display_name').notNull(),
+   email: text('email'),
    isAnonymous: boolean('is_anonymous').notNull().default(true),
    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 });

--- a/supabase/migrations/20260617000000_users_email_mirror.sql
+++ b/supabase/migrations/20260617000000_users_email_mirror.sql
@@ -1,0 +1,80 @@
+-- Mirror auth.users.email into public.users.email.
+--
+-- Why: enables joining game data with email-based external systems
+-- (HubSpot, Stripe) and surfacing the host email on the admin rooms
+-- page without round-tripping the Supabase Admin API on every render.
+--
+-- PII handling: email is restricted by the existing users_self_read RLS
+-- policy on public.users (auth.uid() = id). No SECURITY DEFINER function
+-- in this repo exposes the new column. Admin reads use Drizzle (service
+-- role) and are gated by ADMIN_EMAILS, so the admin page surface is
+-- already restricted.
+--
+-- Anon users have email = null; the column stays nullable.
+
+alter table public.users
+   add column if not exists email text;
+
+-- handle_new_user runs on auth.users INSERT. Capture email on signup.
+-- (Anonymous signups have email = null; raw_user_meta_data is still the
+-- source of truth for display_name overrides.)
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.users (id, display_name, email, is_anonymous)
+  values (
+    new.id,
+    coalesce(
+      new.raw_user_meta_data ->> 'display_name',
+      'Crewmate #' || lpad((floor(random() * 10000))::int::text, 4, '0')
+    ),
+    new.email,
+    coalesce(new.is_anonymous, true)
+  )
+  on conflict (id) do nothing;
+
+  insert into public.user_stats (user_id)
+  values (new.id)
+  on conflict (user_id) do nothing;
+
+  return new;
+end;
+$$;
+
+-- Anon → email upgrade path: AccountLinkModal calls supabase.auth.updateUser
+-- with the email, which sets auth.users.email AFTER the public.users row
+-- already exists. Without this trigger our mirror would silently drift.
+create or replace function public.sync_user_email()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+   if new.email is distinct from old.email then
+      update public.users
+         set email = new.email
+       where id = new.id;
+   end if;
+   return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_email_update on auth.users;
+create trigger on_auth_user_email_update
+   after update of email on auth.users
+   for each row
+   when (new.email is distinct from old.email)
+   execute function public.sync_user_email();
+
+-- One-time backfill for existing rows. auth.users is fully readable by
+-- the service role running the migration.
+update public.users u
+   set email = a.email
+  from auth.users a
+ where a.id = u.id
+   and u.email is distinct from a.email;


### PR DESCRIPTION
## Summary

Brings Greedy Pirate up to par with standard web-app account management. Mirrors `auth.users.email` into `public.users`, surfaces it on `/profile` and the admin rooms table, and adds the three common flows: change email, change password (signed-in), and forgot password (signed-out + reset page). Also cleans up three unused `package.json` scripts.

## Per-change breakdown

### DB
- **`supabase/migrations/20260617000000_users_email_mirror.sql`**
  - `alter table public.users add column if not exists email text`.
  - Updates `handle_new_user` to capture `new.email` on insert.
  - Adds `sync_user_email` SECURITY DEFINER function + a trigger on `auth.users UPDATE OF email`, so anon → email upgrades (done via `AccountLinkModal` -> `updateUser({email})`) sync into our mirror.
  - One-time backfill `update public.users u set email = a.email from auth.users a where a.id = u.id`.
- **`src/server/db/schema.ts`** — adds nullable `email` column on `users`.

### Auth routes
- **`app/auth/callback/route.ts`** — Route Handler that exchanges Supabase PKCE codes via `supabase.auth.exchangeCodeForSession(code)`. Branches on `?type`:
  - `recovery` → `/auth/reset`
  - `email_change` → `/profile?auth=email-changed`
  - default → `?next=` if present, else `/profile`
  - Auth failures → `/profile?auth=failed | missing-code`
- **`app/auth/reset/page.tsx` + `ResetPasswordForm.tsx`** — Set-new-password screen reached from password recovery links. Requires an active session (the PKCE exchange gave us one). Redirects to home if no session.

### Account settings UI
- **`src/client/auth/AccountSettings.tsx`** — two collapsible panels on `/profile`:
  - **Change email**: reauth via `signInWithPassword`, then `updateUser({email}, {emailRedirectTo})`. Supabase mails a confirmation link to the new address (and the old one if "Secure email change" is on). UI shows "check your inbox" state.
  - **Change password**: reauth via `signInWithPassword`, then `updateUser({password})`. Update is immediate, no email round-trip.
- **`app/profile/page.tsx`**
  - Renders the current email below the display name.
  - Renders `<AccountSettings />` at the bottom of the signed-in branch.
  - Renders a status banner from `?auth=email-changed | password-reset | failed | missing-code`.
- **`src/client/auth/AccountLinkModal.tsx`** — adds a **Forgot password?** link in sign-in mode that calls `resetPasswordForEmail(email, { redirectTo: '/auth/callback?type=recovery' })`. Uses the email already typed in the form; surfaces an inline confirmation.

### Admin page
- **`app/admin/rooms/page.tsx`** + **`RoomsTable.tsx`** — Host cell now shows display name above a smaller muted email (or "anon" if null). Host column widened 110px → 180px.

### Scripts + docs
- **`package.json`** — drop `db:push` (bypasses migration files), `db:studio` (redundant with Supabase Studio at `:54323`), and `supabase:push` (folded into `db:migrate:all`).
- **`README.md`** — drop refs to removed scripts; document `db:migrate:all`.
- **`.claude/docs/supabase-setup.md`**
  - Document `ADMIN_EMAILS` + `NEXT_PUBLIC_ADMIN_EMAILS` in the Vercel env var table.
  - Add `https://*.vercel.app/**` to the Redirect URLs list for preview deploys.
  - Add the **Authentication → Email → Secure email change** recommendation.
  - Drop the Drizzle Studio row.
- **`.claude/docs/database.md`** — document the new `email` column on `public.users`.

## PII safety

- `public.users.email` is protected by the existing `users_self_read` RLS policy (`auth.uid() = id`). No other authenticated user can read another user's email via the anon-scoped client.
- `list_public_rooms()` and all other `SECURITY DEFINER` functions still select only `display_name` — they do not surface email.
- Admin reads go through Drizzle (service role bypasses RLS) but the entire admin surface is gated by `ADMIN_EMAILS` at both the page (`notFound()` for non-admins) and server-action layers.

## Supabase Dashboard config required before this can ship

These are not in code — set them once per project:

1. **Auth → URL Configuration**
   - Site URL: production domain
   - Redirect URLs: prod domain, `https://*.vercel.app/**`, `http://localhost:3000/**` — all with `/auth/callback`-compatible patterns
2. **Auth → Email**
   - Enable **Secure email change** (double-confirm). Strongly recommended.

## Local testing

```bash
# Run new migration locally
supabase db push --local
# (or all migrations end-to-end)
npm run db:migrate:all
```

Mailpit catches every auth email at `http://127.0.0.1:54324` — change-email confirmations, password resets, and signup confirmations all land there.

## Test plan

- [ ] Run `supabase db push --local`; confirm `public.users` gains an `email` column and existing rows are backfilled from `auth.users.email`.
- [ ] Sign up as a new user via `AccountLinkModal`; confirm `public.users.email` is set immediately by the trigger.
- [ ] As an anon user, claim an account through `AccountUpgrade` on `/profile`; confirm `public.users.email` is populated via the `sync_user_email` trigger.
- [ ] On `/profile`, open **Change email**, reauth with current password, submit a new email; check Mailpit, click the link; confirm `/profile?auth=email-changed` banner and `public.users.email` updated.
- [ ] On `/profile`, open **Change password**, reauth + new password; sign out + sign in with new password.
- [ ] Sign out, open the sign-in modal, click **Forgot password?**, check Mailpit, click link; land on `/auth/reset`; set new password; redirected to `/profile?auth=password-reset`.
- [ ] As admin, open `/admin/rooms` — host email visible under display name for claimed users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)