### PR TITLE
feat: themed auth email templates + Resend SMTP scaffold

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -234,21 +234,29 @@ otp_length = 6
 # Number of seconds before the email OTP expires (defaults to 1 hour).
 otp_expiry = 3600
 
-# Custom SMTP via Resend. Free tier = 3,000 emails/mo, 100/day.
-# To enable in prod/preview:
-#   1. Create Resend account, verify a sending domain (DKIM + SPF).
-#   2. Set RESEND_API_KEY as a Vercel + Supabase env var.
-#   3. Uncomment the block below and push config:
-#        supabase config push --project-ref <ref>
-# Until enabled, the default Supabase SMTP (noreply@mail.app.supabase.io,
-# 3/hr rate limit, "Powered by Supabase" footer) is used.
+# SMTP is configured via the Resend ↔ Supabase integration in the
+# Supabase dashboard (Auth → Emails → SMTP). The integration writes the
+# API key + sender details directly into the project's secrets, so
+# nothing about SMTP needs to live in this file. Reference values
+# currently set in the dashboard for both prod + preview projects:
+#   host = "smtp.resend.com"
+#   port = 465
+#   user = "resend"
+#   sender_email = "crewmate@greedypirate.com"
+#   sender_name = "Greedy Pirate"
+# Free tier limits: 3,000 emails/mo, 100/day.
+#
+# Keep this block commented. Uncommenting and pushing would attempt to
+# override the integration-managed config with `env(RESEND_API_KEY)`,
+# which we deliberately do NOT set on Supabase (the integration has
+# its own copy).
 # [auth.email.smtp]
 # enabled = true
 # host = "smtp.resend.com"
 # port = 465
 # user = "resend"
 # pass = "env(RESEND_API_KEY)"
-# admin_email = "noreply@yourdomain.example"
+# admin_email = "crewmate@greedypirate.com"
 # sender_name = "Greedy Pirate"
 
 # Greedy Pirate-themed email templates. Subjects + HTML bodies override

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -234,26 +234,42 @@ otp_length = 6
 # Number of seconds before the email OTP expires (defaults to 1 hour).
 otp_expiry = 3600
 
-# Use a production-ready SMTP server
+# Custom SMTP via Resend. Free tier = 3,000 emails/mo, 100/day.
+# To enable in prod/preview:
+#   1. Create Resend account, verify a sending domain (DKIM + SPF).
+#   2. Set RESEND_API_KEY as a Vercel + Supabase env var.
+#   3. Uncomment the block below and push config:
+#        supabase config push --project-ref <ref>
+# Until enabled, the default Supabase SMTP (noreply@mail.app.supabase.io,
+# 3/hr rate limit, "Powered by Supabase" footer) is used.
 # [auth.email.smtp]
 # enabled = true
-# host = "smtp.sendgrid.net"
-# port = 587
-# user = "apikey"
-# pass = "env(SENDGRID_API_KEY)"
-# admin_email = "admin@email.com"
-# sender_name = "Admin"
+# host = "smtp.resend.com"
+# port = 465
+# user = "resend"
+# pass = "env(RESEND_API_KEY)"
+# admin_email = "noreply@yourdomain.example"
+# sender_name = "Greedy Pirate"
 
-# Uncomment to customize email template
-# [auth.email.template.invite]
-# subject = "You have been invited"
-# content_path = "./supabase/templates/invite.html"
+# Greedy Pirate-themed email templates. Subjects + HTML bodies override
+# the default Supabase copy. Variables available per template:
+#   {{ .ConfirmationURL }}  {{ .Email }}  {{ .NewEmail }}  {{ .SiteURL }}
+#   {{ .Token }}  {{ .TokenHash }}  {{ .RedirectTo }}
+[auth.email.template.confirmation]
+subject = "Welcome aboard — confirm yer ship's papers"
+content_path = "./supabase/templates/confirmation.html"
 
-# Uncomment to customize notification email template
-# [auth.email.notification.password_changed]
-# enabled = true
-# subject = "Your password has been changed"
-# content_path = "./templates/password_changed_notification.html"
+[auth.email.template.email_change]
+subject = "Confirm yer new email, crewmate"
+content_path = "./supabase/templates/email_change.html"
+
+[auth.email.template.recovery]
+subject = "Reset yer plunder password"
+content_path = "./supabase/templates/recovery.html"
+
+[auth.email.template.magic_link]
+subject = "Yer boarding pass, crewmate"
+content_path = "./supabase/templates/magic_link.html"
 
 [auth.sms]
 # Allow/disallow new user signups via SMS to your project.

--- a/supabase/templates/README.md
+++ b/supabase/templates/README.md
@@ -1,0 +1,46 @@
+# Email templates
+
+Greedy Pirate-themed HTML for the Supabase Auth transactional emails.
+
+## Files
+
+| File                 | Trigger                                                       |
+| -------------------- | ------------------------------------------------------------- |
+| `confirmation.html`  | First-time signup confirm (signup with email + password).     |
+| `email_change.html`  | Anon → email upgrade and the change-email flow on `/profile`. |
+| `recovery.html`      | Password reset (Forgot password? link in the auth modal).     |
+| `magic_link.html`    | Passwordless sign-in (not currently wired into the UI).       |
+
+The bindings live in `supabase/config.toml` under `[auth.email.template.*]`.
+
+## Template variables
+
+Supabase substitutes these at send time:
+
+- `{{ .ConfirmationURL }}` — the action link (always include this as the CTA).
+- `{{ .Email }}` — the user's current email.
+- `{{ .NewEmail }}` — the pending new email (only meaningful in `email_change`).
+- `{{ .SiteURL }}` — the configured site URL.
+- `{{ .Token }}`, `{{ .TokenHash }}`, `{{ .RedirectTo }}` — rarely needed for HTML emails.
+
+## Deploying changes to the cloud projects
+
+Migrations auto-apply on Vercel build, but **auth config (templates + SMTP) does not**. Push it explicitly with the Supabase CLI:
+
+```bash
+export SUPABASE_ACCESS_TOKEN=...  # personal access token from app.supabase.com/account/tokens
+
+# Production
+supabase link --project-ref fyuasgpjrphxrituofsm
+supabase config push
+
+# Preview
+supabase link --project-ref iosokzbammerxzyfuboc
+supabase config push
+```
+
+Re-run after any change to the templates or to the `[auth.email.*]` blocks in `config.toml`.
+
+## Local testing
+
+`supabase start` serves these templates via the local Auth server. Trigger an email (signup, password reset, etc.) and inspect it at <http://127.0.0.1:54324> (Inbucket).

--- a/supabase/templates/README.md
+++ b/supabase/templates/README.md
@@ -25,21 +25,24 @@ Supabase substitutes these at send time:
 
 ## Deploying changes to the cloud projects
 
-Migrations auto-apply on Vercel build, but **auth config (templates + SMTP) does not**. Push it explicitly with the Supabase CLI:
+Migrations auto-apply on Vercel build, but **auth config (templates) does not**. Push it explicitly with the Supabase CLI:
 
 ```bash
-export SUPABASE_ACCESS_TOKEN=...  # personal access token from app.supabase.com/account/tokens
+# One-time: authenticate the CLI (opens a browser)
+supabase login
+
+# Preview first — verify rendering before touching prod
+supabase link --project-ref iosokzbammerxzyfuboc
+supabase config push
 
 # Production
 supabase link --project-ref fyuasgpjrphxrituofsm
 supabase config push
-
-# Preview
-supabase link --project-ref iosokzbammerxzyfuboc
-supabase config push
 ```
 
-Re-run after any change to the templates or to the `[auth.email.*]` blocks in `config.toml`.
+`supabase config push` only sends what is explicitly set in this repo's `config.toml`. The dashboard-managed SMTP credentials (set up via the Resend ↔ Supabase integration) are left untouched.
+
+Re-run after any change to the templates or to the `[auth.email.template.*]` blocks in `config.toml`.
 
 ## Local testing
 

--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+   <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width,initial-scale=1" />
+      <title>Welcome aboard, crewmate</title>
+   </head>
+   <body style="margin:0;padding:0;background:#0b1424;font-family:'Trebuchet MS','Helvetica Neue',Arial,sans-serif;color:#f4e9d2;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0b1424;padding:24px 12px;">
+         <tr>
+            <td align="center">
+               <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#13203a;border:1px solid #2a3a5e;border-radius:14px;overflow:hidden;">
+                  <tr>
+                     <td style="padding:28px 32px 8px 32px;text-align:center;">
+                        <div style="font-family:'Georgia','Times New Roman',serif;font-size:28px;letter-spacing:0.5px;color:#ffcb53;text-shadow:0 1px 0 #000;">⚓ Greedy Pirate</div>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:8px 32px 0 32px;text-align:center;">
+                        <div style="height:1px;background:linear-gradient(90deg,transparent,#ffcb53,transparent);opacity:0.6;"></div>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:28px 32px 8px 32px;">
+                        <h1 style="margin:0 0 14px 0;font-family:'Georgia','Times New Roman',serif;font-size:26px;color:#ffcb53;">Welcome aboard, crewmate</h1>
+                        <p style="margin:0 0 14px 0;font-size:15px;line-height:1.55;color:#f4e9d2;">
+                           Tap the seal below to confirm <strong style="color:#ffd773;">{{ .Email }}</strong> and start stashin' yer doubloons.
+                        </p>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" style="padding:16px 32px 24px 32px;">
+                        <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:14px 28px;background:linear-gradient(180deg,#ff3b8a,#c1255e);color:#fff5dc;font-family:'Georgia','Times New Roman',serif;font-size:17px;text-decoration:none;border-radius:10px;border:1px solid #ffcb53;box-shadow:0 4px 14px rgba(0,0,0,0.45),inset 0 1px 0 rgba(255,255,255,0.15);">
+                           ⚓ Confirm and board
+                        </a>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:0 32px 24px 32px;">
+                        <p style="margin:0 0 8px 0;font-size:13px;line-height:1.55;color:#b9b0a0;">
+                           Or copy this link into yer browser:
+                        </p>
+                        <p style="margin:0;font-size:12px;line-height:1.5;color:#7da9c2;word-break:break-all;">
+                           <a href="{{ .ConfirmationURL }}" style="color:#7da9c2;text-decoration:underline;">{{ .ConfirmationURL }}</a>
+                        </p>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:18px 32px 28px 32px;border-top:1px solid #2a3a5e;background:#0e192f;">
+                        <p style="margin:0;font-size:12px;line-height:1.5;color:#8f8470;">
+                           Didn't sign up? Toss this letter overboard — no account was created.
+                        </p>
+                     </td>
+                  </tr>
+               </table>
+               <p style="margin:14px 0 0 0;font-size:11px;color:#5e6b80;">Sent by Greedy Pirate · A risk-and-reward card game</p>
+            </td>
+         </tr>
+      </table>
+   </body>
+</html>

--- a/supabase/templates/email_change.html
+++ b/supabase/templates/email_change.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+   <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width,initial-scale=1" />
+      <title>Confirm yer new email</title>
+   </head>
+   <body style="margin:0;padding:0;background:#0b1424;font-family:'Trebuchet MS','Helvetica Neue',Arial,sans-serif;color:#f4e9d2;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0b1424;padding:24px 12px;">
+         <tr>
+            <td align="center">
+               <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#13203a;border:1px solid #2a3a5e;border-radius:14px;overflow:hidden;">
+                  <tr>
+                     <td style="padding:28px 32px 8px 32px;text-align:center;">
+                        <div style="font-family:'Georgia','Times New Roman',serif;font-size:28px;letter-spacing:0.5px;color:#ffcb53;text-shadow:0 1px 0 #000;">⚓ Greedy Pirate</div>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:8px 32px 0 32px;text-align:center;">
+                        <div style="height:1px;background:linear-gradient(90deg,transparent,#ffcb53,transparent);opacity:0.6;"></div>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:28px 32px 8px 32px;">
+                        <h1 style="margin:0 0 14px 0;font-family:'Georgia','Times New Roman',serif;font-size:26px;color:#ffcb53;">Confirm yer new email, crewmate</h1>
+                        <p style="margin:0 0 14px 0;font-size:15px;line-height:1.55;color:#f4e9d2;">
+                           Ye asked to chart <strong style="color:#ffd773;">{{ .NewEmail }}</strong> as yer new mailing address. Tap the seal below to make it official.
+                        </p>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" style="padding:16px 32px 24px 32px;">
+                        <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:14px 28px;background:linear-gradient(180deg,#ff3b8a,#c1255e);color:#fff5dc;font-family:'Georgia','Times New Roman',serif;font-size:17px;text-decoration:none;border-radius:10px;border:1px solid #ffcb53;box-shadow:0 4px 14px rgba(0,0,0,0.45),inset 0 1px 0 rgba(255,255,255,0.15);">
+                           ⚓ Confirm new email
+                        </a>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:0 32px 24px 32px;">
+                        <p style="margin:0 0 8px 0;font-size:13px;line-height:1.55;color:#b9b0a0;">
+                           Or copy this link into yer browser:
+                        </p>
+                        <p style="margin:0;font-size:12px;line-height:1.5;color:#7da9c2;word-break:break-all;">
+                           <a href="{{ .ConfirmationURL }}" style="color:#7da9c2;text-decoration:underline;">{{ .ConfirmationURL }}</a>
+                        </p>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:18px 32px 28px 32px;border-top:1px solid #2a3a5e;background:#0e192f;">
+                        <p style="margin:0;font-size:12px;line-height:1.5;color:#8f8470;">
+                           Didn't request this? Toss this letter overboard — yer account stays right where it is.
+                        </p>
+                     </td>
+                  </tr>
+               </table>
+               <p style="margin:14px 0 0 0;font-size:11px;color:#5e6b80;">Sent by Greedy Pirate · A risk-and-reward card game</p>
+            </td>
+         </tr>
+      </table>
+   </body>
+</html>

--- a/supabase/templates/magic_link.html
+++ b/supabase/templates/magic_link.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+   <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width,initial-scale=1" />
+      <title>Yer magic boarding pass</title>
+   </head>
+   <body style="margin:0;padding:0;background:#0b1424;font-family:'Trebuchet MS','Helvetica Neue',Arial,sans-serif;color:#f4e9d2;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0b1424;padding:24px 12px;">
+         <tr>
+            <td align="center">
+               <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#13203a;border:1px solid #2a3a5e;border-radius:14px;overflow:hidden;">
+                  <tr>
+                     <td style="padding:28px 32px 8px 32px;text-align:center;">
+                        <div style="font-family:'Georgia','Times New Roman',serif;font-size:28px;letter-spacing:0.5px;color:#ffcb53;text-shadow:0 1px 0 #000;">⚓ Greedy Pirate</div>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:8px 32px 0 32px;text-align:center;">
+                        <div style="height:1px;background:linear-gradient(90deg,transparent,#ffcb53,transparent);opacity:0.6;"></div>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:28px 32px 8px 32px;">
+                        <h1 style="margin:0 0 14px 0;font-family:'Georgia','Times New Roman',serif;font-size:26px;color:#ffcb53;">Yer boarding pass, crewmate</h1>
+                        <p style="margin:0 0 14px 0;font-size:15px;line-height:1.55;color:#f4e9d2;">
+                           Tap below to step aboard as <strong style="color:#ffd773;">{{ .Email }}</strong>. No password required.
+                        </p>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" style="padding:16px 32px 24px 32px;">
+                        <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:14px 28px;background:linear-gradient(180deg,#ff3b8a,#c1255e);color:#fff5dc;font-family:'Georgia','Times New Roman',serif;font-size:17px;text-decoration:none;border-radius:10px;border:1px solid #ffcb53;box-shadow:0 4px 14px rgba(0,0,0,0.45),inset 0 1px 0 rgba(255,255,255,0.15);">
+                           ⚓ Sign in
+                        </a>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:0 32px 24px 32px;">
+                        <p style="margin:0 0 8px 0;font-size:13px;line-height:1.55;color:#b9b0a0;">
+                           Or copy this link into yer browser:
+                        </p>
+                        <p style="margin:0;font-size:12px;line-height:1.5;color:#7da9c2;word-break:break-all;">
+                           <a href="{{ .ConfirmationURL }}" style="color:#7da9c2;text-decoration:underline;">{{ .ConfirmationURL }}</a>
+                        </p>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:18px 32px 28px 32px;border-top:1px solid #2a3a5e;background:#0e192f;">
+                        <p style="margin:0;font-size:12px;line-height:1.5;color:#8f8470;">
+                           Didn't ask for this? Toss this letter overboard.
+                        </p>
+                     </td>
+                  </tr>
+               </table>
+               <p style="margin:14px 0 0 0;font-size:11px;color:#5e6b80;">Sent by Greedy Pirate · A risk-and-reward card game</p>
+            </td>
+         </tr>
+      </table>
+   </body>
+</html>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+   <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width,initial-scale=1" />
+      <title>Reset yer password</title>
+   </head>
+   <body style="margin:0;padding:0;background:#0b1424;font-family:'Trebuchet MS','Helvetica Neue',Arial,sans-serif;color:#f4e9d2;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0b1424;padding:24px 12px;">
+         <tr>
+            <td align="center">
+               <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#13203a;border:1px solid #2a3a5e;border-radius:14px;overflow:hidden;">
+                  <tr>
+                     <td style="padding:28px 32px 8px 32px;text-align:center;">
+                        <div style="font-family:'Georgia','Times New Roman',serif;font-size:28px;letter-spacing:0.5px;color:#ffcb53;text-shadow:0 1px 0 #000;">⚓ Greedy Pirate</div>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:8px 32px 0 32px;text-align:center;">
+                        <div style="height:1px;background:linear-gradient(90deg,transparent,#ffcb53,transparent);opacity:0.6;"></div>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:28px 32px 8px 32px;">
+                        <h1 style="margin:0 0 14px 0;font-family:'Georgia','Times New Roman',serif;font-size:26px;color:#ffcb53;">Forgot yer plunder password?</h1>
+                        <p style="margin:0 0 14px 0;font-size:15px;line-height:1.55;color:#f4e9d2;">
+                           Tap the seal below to choose a new one for <strong style="color:#ffd773;">{{ .Email }}</strong>. The link be good for one hour — after that the chest locks back up.
+                        </p>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td align="center" style="padding:16px 32px 24px 32px;">
+                        <a href="{{ .ConfirmationURL }}" style="display:inline-block;padding:14px 28px;background:linear-gradient(180deg,#ff3b8a,#c1255e);color:#fff5dc;font-family:'Georgia','Times New Roman',serif;font-size:17px;text-decoration:none;border-radius:10px;border:1px solid #ffcb53;box-shadow:0 4px 14px rgba(0,0,0,0.45),inset 0 1px 0 rgba(255,255,255,0.15);">
+                           ⚓ Reset password
+                        </a>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:0 32px 24px 32px;">
+                        <p style="margin:0 0 8px 0;font-size:13px;line-height:1.55;color:#b9b0a0;">
+                           Or copy this link into yer browser:
+                        </p>
+                        <p style="margin:0;font-size:12px;line-height:1.5;color:#7da9c2;word-break:break-all;">
+                           <a href="{{ .ConfirmationURL }}" style="color:#7da9c2;text-decoration:underline;">{{ .ConfirmationURL }}</a>
+                        </p>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td style="padding:18px 32px 28px 32px;border-top:1px solid #2a3a5e;background:#0e192f;">
+                        <p style="margin:0;font-size:12px;line-height:1.5;color:#8f8470;">
+                           Didn't ask to reset? Toss this letter overboard — yer current password be untouched.
+                        </p>
+                     </td>
+                  </tr>
+               </table>
+               <p style="margin:14px 0 0 0;font-size:11px;color:#5e6b80;">Sent by Greedy Pirate · A risk-and-reward card game</p>
+            </td>
+         </tr>
+      </table>
+   </body>
+</html>


### PR DESCRIPTION
## Summary
- Replaces the four Supabase auth emails the app actually triggers (confirmation, email change, password recovery, magic link) with Greedy-Pirate-themed HTML.
- Scaffolds a Resend SMTP block in `config.toml` (commented) so the next step is just creating the Resend account, verifying a sending domain, and setting `RESEND_API_KEY`. Free tier = 3K/mo, 100/day.
- Adds `supabase/templates/README.md` documenting variables and the per-project `supabase config push` step.

## Per-change breakdown

### `supabase/templates/confirmation.html`
First-time signup confirm. CTA: "Confirm and board". Uses `{{ .Email }}` and `{{ .ConfirmationURL }}`.

### `supabase/templates/email_change.html`
Used by anon → email upgrade (the painful path that started this thread) and by the change-email flow on `/profile`. CTA: "Confirm new email". Uses `{{ .NewEmail }}` and `{{ .ConfirmationURL }}`.

### `supabase/templates/recovery.html`
Password reset (Forgot password? link in the auth modal). CTA: "Reset password". Mentions 1h expiry.

### `supabase/templates/magic_link.html`
Not currently wired into the UI but ships themed in case we add passwordless sign-in later. CTA: "Sign in".

All four use the same dark-navy shell (`#0b1424` background, `#13203a` card, gold horizontal-rule ornament, coral gradient CTA button matching `PirateButton`). Inline styles + `<table>` layout for email-client safety.

### `supabase/config.toml`
- Adds four `[auth.email.template.*]` blocks binding each HTML file with a themed subject:
  - `confirmation` → "Welcome aboard — confirm yer ship's papers"
  - `email_change` → "Confirm yer new email, crewmate"
  - `recovery` → "Reset yer plunder password"
  - `magic_link` → "Yer boarding pass, crewmate"
- Replaces the SendGrid stub under `[auth.email.smtp]` with a Resend stub (host `smtp.resend.com`, port 465, user `resend`, pass `env(RESEND_API_KEY)`). Kept commented — activates once the user has an account + domain.

### `supabase/templates/README.md`
- Lists which template fires for which app flow.
- Documents the template variables Supabase substitutes.
- Spells out the `supabase config push` deployment step for both prod and preview refs, because the Vercel build's `supabase db push` does not deploy auth config.

## Deploying after merge
Auth config is **not** part of `supabase db push`, so the Vercel build won't pick it up automatically. One-time (or after future template edits):

```bash
export SUPABASE_ACCESS_TOKEN=...  # personal access token

supabase link --project-ref fyuasgpjrphxrituofsm  # prod
supabase config push

supabase link --project-ref iosokzbammerxzyfuboc  # preview
supabase config push
```

## Test plan
- [ ] After `supabase config push` to preview, trigger a signup → confirmation email arrives with the new HTML + subject.
- [ ] Anon → email upgrade → email_change template, "Confirm new email" CTA visible.
- [ ] Forgot password from sign-in modal → recovery template.
- [ ] Inline rendering looks correct in Gmail (web + iOS), Apple Mail, Outlook web.
- [ ] CTA link still routes to `/auth/callback?code=...&type=...`.

## Follow-ups
- **Sign up for Resend, verify a sending domain (DKIM + SPF DNS records).** Subdomain like `mail.greedypirate.app` works. Set `RESEND_API_KEY` in Vercel env and uncomment `[auth.email.smtp]` to flip off the default Supabase sender + remove the "Powered by Supabase" footer.
- Optional: extend `scripts/ci-migrate.mjs` to also run `supabase config push` on Vercel builds so future template changes auto-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)