### PR TITLE
feat: themed password recovery flow (handles PKCE + implicit + Site URL fallback)

### DIFF
--- a/app/auth/reset/ResetPasswordForm.tsx
+++ b/app/auth/reset/ResetPasswordForm.tsx
@@ -1,29 +1,113 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import type { AuthChangeEvent, Session, User } from '@supabase/supabase-js';
 import { getSupabaseBrowser } from '@/client/supabase/browser';
+import { emitProfileChanged } from '@/client/auth/useCurrentUser';
 import { PirateButton } from '@/ui/pirate-button/PirateButton';
 
 const MIN_PASSWORD = 8;
 
-export function ResetPasswordForm() {
+type State = 'waiting' | 'ready' | 'expired';
+
+interface Props {
+   /**
+    * Server-side error pulled from `?error=` query params. We surface it
+    * immediately. Hash-based `#error=` shows up at runtime via the
+    * effect below.
+    */
+   initialError: string | null;
+}
+
+export function ResetPasswordForm({ initialError }: Props) {
    const router = useRouter();
+   const [state, setState] = useState<State>(initialError ? 'expired' : 'waiting');
+   const [errorMsg, setErrorMsg] = useState<string | null>(initialError);
+   const [user, setUser] = useState<User | null>(null);
+
    const [password, setPassword] = useState('');
    const [confirm, setConfirm] = useState('');
-   const [error, setError] = useState<string | null>(null);
+   const [showPassword, setShowPassword] = useState(false);
+   const [formError, setFormError] = useState<string | null>(null);
    const [submitting, setSubmitting] = useState(false);
+   const [resending, setResending] = useState(false);
+   const [resendInfo, setResendInfo] = useState<string | null>(null);
+
+   useEffect(() => {
+      if (state === 'expired') return;
+      const supabase = getSupabaseBrowser();
+
+      // Hash flow: Supabase puts an error fragment when the OTP is
+      // expired or invalid. Surface it the same way the server-side
+      // error path does.
+      if (typeof window !== 'undefined' && window.location.hash.length > 1) {
+         const params = new URLSearchParams(window.location.hash.slice(1));
+         const hashError = params.get('error_description') ?? params.get('error');
+         if (hashError) {
+            setErrorMsg(decodeURIComponent(hashError.replace(/\+/g, ' ')));
+            setState('expired');
+            return;
+         }
+      }
+
+      let active = true;
+
+      const claim = async () => {
+         const {
+            data: { user: current },
+         } = await supabase.auth.getUser();
+         if (!active) return;
+         if (current) {
+            setUser(current);
+            setState('ready');
+         }
+      };
+
+      // PKCE flow: session already in cookies from server exchange.
+      // Implicit flow: SDK reads hash on init, fires PASSWORD_RECOVERY.
+      void claim();
+
+      const { data: sub } = supabase.auth.onAuthStateChange(
+         (event: AuthChangeEvent, session: Session | null) => {
+            if (!active) return;
+            if (event === 'PASSWORD_RECOVERY' || (event === 'SIGNED_IN' && session)) {
+               setUser(session?.user ?? null);
+               setState('ready');
+            }
+         },
+      );
+
+      // If no session shows up within a few seconds, treat it as a
+      // broken link rather than spinning forever.
+      const timeout = window.setTimeout(() => {
+         if (!active) return;
+         setState((prev) => {
+            if (prev === 'waiting') {
+               setErrorMsg('Recovery link expired or invalid. Request a new one below.');
+               return 'expired';
+            }
+            return prev;
+         });
+      }, 4000);
+
+      return () => {
+         active = false;
+         sub.subscription.unsubscribe();
+         window.clearTimeout(timeout);
+      };
+   }, [state]);
 
    const submit = async (e: React.FormEvent) => {
       e.preventDefault();
-      setError(null);
+      setFormError(null);
 
       if (password.length < MIN_PASSWORD) {
-         setError(`Password must be at least ${MIN_PASSWORD} characters`);
+         setFormError(`Password must be at least ${MIN_PASSWORD} characters`);
          return;
       }
       if (password !== confirm) {
-         setError('Passwords do not match');
+         setFormError('Passwords do not match');
          return;
       }
 
@@ -32,43 +116,160 @@ export function ResetPasswordForm() {
       const { error: updateError } = await supabase.auth.updateUser({ password });
       setSubmitting(false);
       if (updateError) {
-         setError(updateError.message);
+         setFormError(updateError.message);
          return;
       }
+      emitProfileChanged();
       router.push('/profile?auth=password-reset');
       router.refresh();
    };
 
+   const resend = async () => {
+      const email = user?.email ?? promptForEmail();
+      if (!email) return;
+      setResendInfo(null);
+      setResending(true);
+      const supabase = getSupabaseBrowser();
+      const origin = typeof window !== 'undefined' ? window.location.origin : '';
+      const { error: resendError } = await supabase.auth.resetPasswordForEmail(email, {
+         redirectTo: `${origin}/auth/reset`,
+      });
+      setResending(false);
+      if (resendError) {
+         setErrorMsg(resendError.message);
+         return;
+      }
+      setResendInfo(`Sent a fresh recovery link to ${email}.`);
+   };
+
+   if (state === 'expired') {
+      return (
+         <div className='flex flex-col gap-3'>
+            <p className='text-sm text-[color:var(--color-coral-300)]'>
+               {errorMsg ?? 'This recovery link is no longer valid.'}
+            </p>
+            <p className='text-sm text-[color:var(--color-cream-200)]/75'>
+               Request a new link and try again. The latest one ye get is the only one that works — older links expire after the next is sent.
+            </p>
+            {resendInfo && (
+               <p className='text-sm text-[color:var(--color-teal-300)]'>{resendInfo}</p>
+            )}
+            <PirateButton
+               variant='primary'
+               size='md'
+               fullWidth
+               onClick={resend}
+               loading={resending}
+            >
+               Send a new link
+            </PirateButton>
+            <button
+               type='button'
+               onClick={() => router.push('/')}
+               className='min-h-[44px] text-sm text-[color:var(--color-cream-200)]/60 underline-offset-4 hover:underline'
+            >
+               Back to home
+            </button>
+         </div>
+      );
+   }
+
+   if (state === 'waiting') {
+      return (
+         <div className='flex items-center justify-center py-6'>
+            <Spinner />
+            <span className='ml-3 text-sm text-[color:var(--color-cream-200)]/70'>
+               Hoisting the colors…
+            </span>
+         </div>
+      );
+   }
+
    return (
       <form onSubmit={submit} className='flex flex-col gap-3'>
+         {user?.email && (
+            <p className='text-sm text-[color:var(--color-cream-200)]/75'>
+               Resetting password for{' '}
+               <span className='font-mono text-[color:var(--color-gold-200)]'>{user.email}</span>.
+            </p>
+         )}
+
          <label className='flex flex-col gap-1 text-sm'>
-            New password
+            <span className='pirate-display text-xs uppercase tracking-wider text-[color:var(--color-cream-200)]/75'>
+               New password
+            </span>
             <input
-               type='password'
+               type={showPassword ? 'text' : 'password'}
                autoComplete='new-password'
                value={password}
                onChange={(e) => setPassword(e.target.value)}
-               className='min-h-[44px] rounded-md border border-white/15 bg-black/30 px-3 text-base'
+               placeholder={`At least ${MIN_PASSWORD} characters`}
+               minLength={MIN_PASSWORD}
+               className='input-pirate min-h-[48px] text-base'
                required
             />
          </label>
+
          <label className='flex flex-col gap-1 text-sm'>
-            Confirm new password
+            <span className='pirate-display text-xs uppercase tracking-wider text-[color:var(--color-cream-200)]/75'>
+               Confirm new password
+            </span>
             <input
-               type='password'
+               type={showPassword ? 'text' : 'password'}
                autoComplete='new-password'
                value={confirm}
                onChange={(e) => setConfirm(e.target.value)}
-               className='min-h-[44px] rounded-md border border-white/15 bg-black/30 px-3 text-base'
+               minLength={MIN_PASSWORD}
+               className='input-pirate min-h-[48px] text-base'
                required
             />
          </label>
-         {error && (
-            <p className='text-sm text-[color:var(--color-coral-300)]'>{error}</p>
+
+         <button
+            type='button'
+            onClick={() => setShowPassword((s) => !s)}
+            className='self-start text-xs font-semibold uppercase tracking-wider text-[color:var(--color-teal-300)] hover:text-[color:var(--color-teal-200)]'
+         >
+            {showPassword ? 'Hide password' : 'Show password'}
+         </button>
+
+         {formError && (
+            <p className='text-sm text-[color:var(--color-coral-400)]'>{formError}</p>
          )}
-         <PirateButton type='submit' loading={submitting} fullWidth>
+
+         <PirateButton
+            type='submit'
+            variant='primary'
+            size='md'
+            fullWidth
+            loading={submitting}
+            disabled={!password || !confirm}
+         >
             Set new password
          </PirateButton>
       </form>
+   );
+}
+
+function promptForEmail(): string | null {
+   if (typeof window === 'undefined') return null;
+   const value = window.prompt('Enter the email tied to yer account:');
+   if (!value) return null;
+   const trimmed = value.trim().toLowerCase();
+   if (!trimmed.includes('@')) return null;
+   return trimmed;
+}
+
+function Spinner() {
+   return (
+      <svg
+         viewBox='0 0 24 24'
+         className='h-6 w-6 animate-spin text-[color:var(--color-gold-300)]'
+         fill='none'
+         aria-label='Loading'
+      >
+         <circle cx='12' cy='12' r='9' stroke='currentColor' strokeOpacity='0.25' strokeWidth='3' />
+         <path d='M21 12a9 9 0 0 1-9 9' stroke='currentColor' strokeWidth='3' strokeLinecap='round' />
+      </svg>
    );
 }

--- a/app/auth/reset/page.tsx
+++ b/app/auth/reset/page.tsx
@@ -1,31 +1,61 @@
-import { redirect } from 'next/navigation';
 import { getSupabaseServer } from '@/server/supabase/server';
+import { PiratePanel } from '@/ui/pirate-panel/PiratePanel';
 import { ResetPasswordForm } from './ResetPasswordForm';
 
 export const dynamic = 'force-dynamic';
 
-export default async function ResetPasswordPage() {
+interface Props {
+   searchParams: Promise<{ code?: string; error?: string; error_description?: string }>;
+}
+
+/**
+ * Password recovery landing.
+ *
+ * Three entry shapes Supabase may produce:
+ *
+ *  1. PKCE flow — `?code=<pkce>`: we exchange server-side and the session
+ *     lands in cookies before the form renders.
+ *  2. Implicit flow — `#access_token=...&type=recovery`: the hash never
+ *     reaches the server. We render the form regardless; the client SDK
+ *     auto-detects the hash on mount and the form waits for a session.
+ *  3. Error — `?error=...` or `#error=...`: render an "expired link"
+ *     panel with a button to request a fresh recovery email.
+ */
+export default async function ResetPasswordPage({ searchParams }: Props) {
+   const params = await searchParams;
    const supabase = await getSupabaseServer();
-   const {
-      data: { user },
-   } = await supabase.auth.getUser();
 
-   // Recovery link lands here via /auth/callback?type=recovery, which
-   // exchanges the PKCE code and gives us a recovery-scoped session.
-   // Without that session there is nothing to do here — punt to home.
-   if (!user) redirect('/');
+   // Surface query-string errors immediately (only the `?error=` shape;
+   // hash errors are caught client-side in the form).
+   const serverError = params.error
+      ? params.error_description ?? params.error
+      : null;
 
+   // PKCE: exchange before rendering so the form sees a session.
+   if (params.code && !serverError) {
+      const { error } = await supabase.auth.exchangeCodeForSession(params.code);
+      if (error) {
+         return <ResetShell error={error.message} />;
+      }
+   }
+
+   return <ResetShell error={serverError} />;
+}
+
+function ResetShell({ error }: { error: string | null }) {
    return (
-      <main className='mx-auto flex w-full max-w-md flex-1 flex-col justify-center gap-6 px-5 py-10 text-[color:var(--color-cream-200)]'>
-         <header>
-            <h1 className='font-display text-3xl uppercase tracking-wider text-[color:var(--color-gold-200)]'>
+      <main className='mx-auto flex w-full max-w-md flex-1 flex-col justify-center gap-5 px-5 py-10'>
+         <header className='text-center'>
+            <h1 className='pirate-display text-3xl text-[color:var(--color-gold-300)] sm:text-4xl'>
                Set a new password
             </h1>
-            <p className='mt-2 text-sm opacity-75'>
-               Resetting for <span className='font-mono'>{user.email}</span>.
+            <p className='mt-2 text-sm text-[color:var(--color-cream-200)]/75'>
+               Pick a fresh password to unlock yer logbook.
             </p>
          </header>
-         <ResetPasswordForm />
+         <PiratePanel variant='deep' className='flex flex-col gap-4'>
+            <ResetPasswordForm initialError={error} />
+         </PiratePanel>
       </main>
    );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import type { Metadata, Viewport } from 'next';
 import { Analytics } from '@vercel/analytics/react';
 import { AuthBootstrap } from '@/client/auth/AuthBootstrap';
+import { RecoveryHashRouter } from '@/client/auth/RecoveryHashRouter';
 import { AmbientSea } from '@/ui/effects/AmbientSea';
 import { TopNav } from '@/ui/top-nav/TopNav';
 
@@ -53,6 +54,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
          <body>
             <AmbientSea />
             <AuthBootstrap>
+               <RecoveryHashRouter />
                {/* Fixed app shell: exactly one viewport tall, no document scroll.
                    Screens that need scrolling (profile) opt in with overflow-y-auto
                    on their own <main> and handle their own bottom safe inset. */}

--- a/src/client/auth/AccountLinkModal.tsx
+++ b/src/client/auth/AccountLinkModal.tsx
@@ -53,8 +53,11 @@ export function AccountLinkModal({ open, onClose, initialMode = 'signup' }: Prop
       setSendingReset(true);
       const supabase = getSupabaseBrowser();
       const origin = typeof window !== 'undefined' ? window.location.origin : '';
+      // Point straight at /auth/reset. The reset page handles both
+      // PKCE (?code=) and implicit (#access_token=...) flows itself, so
+      // there's no need to bounce through /auth/callback first.
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(trimmed, {
-         redirectTo: `${origin}/auth/callback?type=recovery`,
+         redirectTo: `${origin}/auth/reset`,
       });
       setSendingReset(false);
       if (resetError) {

--- a/src/client/auth/RecoveryHashRouter.tsx
+++ b/src/client/auth/RecoveryHashRouter.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+const RESET_PATH = '/auth/reset';
+
+/**
+ * Catches Supabase recovery redirects that land somewhere other than
+ * /auth/reset and reroutes them. Two cases:
+ *
+ *  1. Successful implicit-flow recovery: Supabase appends
+ *     #access_token=...&type=recovery to the redirect_to URL. If the
+ *     redirect_to bounces to Site URL (e.g. PKCE verifier missing), the
+ *     hash lands on `/`. We forward it to /auth/reset, preserving the
+ *     hash so getSupabaseBrowser()'s detectSessionInUrl can claim the
+ *     session there.
+ *
+ *  2. Expired / invalid recovery link: Supabase appends
+ *     #error=access_denied&error_code=otp_expired&... — again to
+ *     redirect_to OR Site URL. /auth/reset renders a "link expired"
+ *     panel with a way to request a fresh link.
+ *
+ * Mounted at the layout level so it runs no matter which page the user
+ * lands on.
+ */
+export function RecoveryHashRouter() {
+   const pathname = usePathname();
+
+   useEffect(() => {
+      if (typeof window === 'undefined') return;
+      if (pathname === RESET_PATH) return;
+      const hash = window.location.hash;
+      if (!hash || hash.length < 2) return;
+
+      const params = new URLSearchParams(hash.slice(1));
+      const isRecovery = params.get('type') === 'recovery';
+      const isAuthError = params.get('error_code')?.startsWith('otp_') ?? false;
+      if (!isRecovery && !isAuthError) return;
+
+      // Hard navigation so window.location.hash is preserved on the
+      // landing page — Next.js client routing can drop it during
+      // server-rendered transitions. The Supabase SDK on /auth/reset
+      // reads the hash via detectSessionInUrl to claim the recovery
+      // session.
+      window.location.replace(`${RESET_PATH}${hash}`);
+   }, [pathname]);
+
+   return null;
+}


### PR DESCRIPTION
## Summary
- Routes password-reset emails directly at `/auth/reset` instead of bouncing through `/auth/callback?type=recovery`. The query-string `?type=recovery` was failing Supabase's redirect URL validator and getting silently replaced with Site URL — landing users on the home page with nothing actionable.
- Reset page now handles the three real entry shapes Supabase produces: PKCE (`?code=`), implicit (`#access_token=...`), and error (`?error=` or `#error=`).
- Layout-level `RecoveryHashRouter` catches recovery hashes that land anywhere other than `/auth/reset` and forwards them, preserving the hash so the SDK can claim the session.
- Reset form rewritten to match the rest of the app (PiratePanel, `input-pirate`, password reveal toggle, themed Spinner, primary PirateButton submit).

## Smoking gun
The recovery email's `&redirect_to=` parameter was rendering as **bare Site URL**:
```
...&redirect_to=https://greedypirate.com
```
not `https://greedypirate.com/auth/callback?type=recovery` as the modal requested. Supabase's URL validator rejected the redirect (likely the query string in the path triggered the wildcard mismatch with `/**`) and substituted the safe default. The fix is to drop the query string entirely — route via `/auth/reset`.

## Per-change breakdown

### `src/client/auth/AccountLinkModal.tsx`
`sendReset` now passes `redirectTo: \`${origin}/auth/reset\`` instead of `\`${origin}/auth/callback?type=recovery\``. Comment explains why.

### `app/auth/reset/page.tsx`
Server component. Reads `?code` and `?error` from the URL.
- If `code`: `exchangeCodeForSession` server-side, populates session cookies before render.
- If `error`: passes the description down to the form so it can show the expired-link UI immediately.
- Always renders the form inside a `PiratePanel`. No early redirect to `/` — even if the user has no session yet (implicit flow), the client picks it up on mount.

### `app/auth/reset/ResetPasswordForm.tsx`
Full rewrite. State machine: `waiting` → `ready` → `expired`.
- On mount, reads `window.location.hash` for `#error=` and surfaces it.
- Calls `auth.getUser()` and subscribes to `onAuthStateChange`. Switches to `ready` when `PASSWORD_RECOVERY` or `SIGNED_IN` fires.
- 4s safety timeout: if no session arrives, flips to `expired` and offers a resend.
- Resend button uses `resetPasswordForEmail` with the new `/auth/reset` redirectTo. Falls back to `prompt()` for the email when the session never landed (user opened from another device).
- Form: PiratePanel container in the page wrapper, `input-pirate` styling, password reveal toggle, primary PirateButton submit. Submits via `updateUser({ password })` and redirects to `/profile?auth=password-reset` (the banner already exists in `profile/page.tsx`).

### `src/client/auth/RecoveryHashRouter.tsx` (new)
Mounted at the layout level. On every pathname change, peeks at `window.location.hash`:
- If `type=recovery` or `error_code=otp_*` and we're NOT already on `/auth/reset`, runs `window.location.replace('/auth/reset' + hash)`. Hard nav (not Next router) so the hash survives the transition for the Supabase SDK to detect.

### `app/layout.tsx`
Mount `<RecoveryHashRouter />` inside `AuthBootstrap`.

## Doesn't touch
- `/auth/callback/route.ts` — left intact for `email_change` and confirmation flows. Recovery branch (`type === 'recovery'`) is unreachable from the new flow but kept for any in-flight links.
- Supabase URL allowlist — unchanged (`https://greedypirate.com/**` already permits `/auth/reset`).

## Test plan
- [ ] On preview after deploy, click Forgot password? → request email → inspect the inline link. `&redirect_to=` should now read `https://yourpreview.vercel.app/auth/reset` (not bare domain).
- [ ] Click CTA on same device → lands on `/auth/reset` form, prefilled with user email.
- [ ] Set a password ≥ 8 chars → submit → land on `/profile?auth=password-reset` with banner.
- [ ] Click an expired link (request a new one before clicking the old) → see "Recovery link expired" UI with Send-a-new-link button.
- [ ] Open the email link on a different browser (no PKCE verifier in storage) — implicit flow should still work via hash detection.
- [ ] Manually visit `https://...#type=recovery&access_token=junk` on `/` → RecoveryHashRouter should bounce to `/auth/reset` showing the expired UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)