### PR TITLE
fix: route recovery PKCE through /auth/callback (HttpOnly verifier)

### DIFF
--- a/app/auth/reset/ResetPasswordForm.tsx
+++ b/app/auth/reset/ResetPasswordForm.tsx
@@ -18,16 +18,9 @@ interface Props {
     * effect below.
     */
    initialError: string | null;
-   /**
-    * PKCE code from `?code=` query param. Exchanged client-side so the
-    * resulting session is persisted in browser cookies (server
-    * components can't write cookies). Null when the link arrived as
-    * an implicit-flow hash instead.
-    */
-   code: string | null;
 }
 
-export function ResetPasswordForm({ initialError, code }: Props) {
+export function ResetPasswordForm({ initialError }: Props) {
    const router = useRouter();
    const [state, setState] = useState<State>(initialError ? 'expired' : 'waiting');
    const [errorMsg, setErrorMsg] = useState<string | null>(initialError);
@@ -61,35 +54,22 @@ export function ResetPasswordForm({ initialError, code }: Props) {
       let active = true;
 
       const claim = async () => {
-         // PKCE flow: exchange the code client-side. Server components
-         // can't write cookies, so this MUST happen here — otherwise
-         // the new session never reaches storage and the form's
-         // updateUser call later runs against the stale anonymous
-         // session.
-         if (code) {
-            const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(code);
-            if (!active) return;
-            if (exchangeError) {
-               setErrorMsg(exchangeError.message);
-               setState('expired');
-               return;
-            }
-         }
-
          const {
             data: { user: current },
          } = await supabase.auth.getUser();
          if (!active) return;
-         // Anonymous users coming through home page auth don't count as
-         // "recovered" — we wait for the real account session to land
-         // via exchangeCodeForSession or the SDK's hash auto-detect.
+         // Anonymous users coming through home page auth don't count
+         // as "recovered" — we wait for the real account session.
+         // /auth/callback handles the PKCE exchange before redirecting
+         // here, so by the time this page mounts the session should
+         // already be in cookies.
          if (current && current.is_anonymous === false) {
             setUser(current);
             setState('ready');
          }
       };
 
-      // PKCE flow: exchange runs above.
+      // PKCE flow: session already in cookies via /auth/callback.
       // Implicit flow: SDK reads hash on init, fires PASSWORD_RECOVERY.
       void claim();
 
@@ -121,7 +101,7 @@ export function ResetPasswordForm({ initialError, code }: Props) {
          sub.subscription.unsubscribe();
          window.clearTimeout(timeout);
       };
-   }, [state, code]);
+   }, [state]);
 
    const submit = async (e: React.FormEvent) => {
       e.preventDefault();
@@ -157,7 +137,7 @@ export function ResetPasswordForm({ initialError, code }: Props) {
       const supabase = getSupabaseBrowser();
       const origin = typeof window !== 'undefined' ? window.location.origin : '';
       const { error: resendError } = await supabase.auth.resetPasswordForEmail(email, {
-         redirectTo: `${origin}/auth/reset`,
+         redirectTo: `${origin}/auth/callback?type=recovery`,
       });
       setResending(false);
       if (resendError) {

--- a/app/auth/reset/page.tsx
+++ b/app/auth/reset/page.tsx
@@ -4,21 +4,21 @@ import { ResetPasswordForm } from './ResetPasswordForm';
 export const dynamic = 'force-dynamic';
 
 interface Props {
-   searchParams: Promise<{ code?: string; error?: string; error_description?: string }>;
+   searchParams: Promise<{ error?: string; error_description?: string }>;
 }
 
 /**
  * Password recovery landing.
  *
- * The PKCE code exchange runs on the CLIENT, not here. Server Components
- * are read-only for cookies, so calling exchangeCodeForSession from this
- * file silently fails to persist the new session — the user keeps their
- * old anonymous cookies and updateUser later errors with "anonymous user
- * without an email". The client form handles all three entry shapes:
+ * The PKCE exchange is done by /auth/callback (a Route Handler that
+ * can read the HttpOnly verifier cookie and write the new session
+ * cookies). By the time we render here, the recovered session is
+ * already in storage. We just hand off to the client form, which
+ * verifies the session and lets the user set a new password.
  *
- *   1. PKCE: ?code=... — client calls exchangeCodeForSession.
- *   2. Implicit: #access_token=...&type=recovery — SDK auto-detects.
- *   3. Error: ?error=... or #error=... — render expired-link UI.
+ * Implicit flow is still supported: if the redirect arrived with
+ * `#access_token=...&type=recovery` (no `?code=`), the Supabase SDK
+ * auto-detects the hash on mount and fires PASSWORD_RECOVERY.
  */
 export default async function ResetPasswordPage({ searchParams }: Props) {
    const params = await searchParams;
@@ -36,7 +36,7 @@ export default async function ResetPasswordPage({ searchParams }: Props) {
             </p>
          </header>
          <PiratePanel variant='deep' className='flex flex-col gap-4'>
-            <ResetPasswordForm initialError={serverError} code={params.code ?? null} />
+            <ResetPasswordForm initialError={serverError} />
          </PiratePanel>
       </main>
    );

--- a/src/client/auth/AccountLinkModal.tsx
+++ b/src/client/auth/AccountLinkModal.tsx
@@ -53,11 +53,15 @@ export function AccountLinkModal({ open, onClose, initialMode = 'signup' }: Prop
       setSendingReset(true);
       const supabase = getSupabaseBrowser();
       const origin = typeof window !== 'undefined' ? window.location.origin : '';
-      // Point straight at /auth/reset. The reset page handles both
-      // PKCE (?code=) and implicit (#access_token=...) flows itself, so
-      // there's no need to bounce through /auth/callback first.
+      // Route through /auth/callback (a Route Handler) so the PKCE
+      // exchange runs server-side. The PKCE verifier is stored as an
+      // HttpOnly cookie by @supabase/ssr — client JS can't read it,
+      // so a client-side exchangeCodeForSession fails with "PKCE code
+      // verifier not found in storage". The route handler can read
+      // the verifier AND write the resulting session cookies, then
+      // redirects to /auth/reset with the session already in place.
       const { error: resetError } = await supabase.auth.resetPasswordForEmail(trimmed, {
-         redirectTo: `${origin}/auth/reset`,
+         redirectTo: `${origin}/auth/callback?type=recovery`,
       });
       setSendingReset(false);
       if (resetError) {


### PR DESCRIPTION
## Summary
Follow-up to #16. The client-side `exchangeCodeForSession` we shipped fails in production with:

> PKCE code verifier not found in storage. This can happen if the auth flow was initiated in a different browser or device, or if the storage was cleared.

— even on the **same** browser. Reason: `@supabase/ssr` stores the PKCE verifier as an **HttpOnly cookie**. Browser JS can't read HttpOnly cookies (by design). Only the server can.

## Why this works
`/auth/callback/route.ts` is a **Route Handler** — runs server-side, can read the HttpOnly verifier AND write new session cookies. It already has the recovery branch: exchange code → redirect to `/auth/reset`. The previous reason this path was broken was the www-vs-apex Supabase allowlist mismatch, which is now fixed (apex is canonical, www 308s to apex).

## Per-change breakdown

### `src/client/auth/AccountLinkModal.tsx`
`sendReset` `redirectTo` back to `\`${origin}/auth/callback?type=recovery\``. Inline comment explains the HttpOnly verifier reason — so future me doesn't try moving it to the client again.

### `app/auth/reset/ResetPasswordForm.tsx`
- Drops the `code` prop and the client `exchangeCodeForSession` call.
- `claim()` just reads the session that `/auth/callback` already established.
- Still skips anonymous sessions (`is_anonymous === false` check kept from #16).
- 4s timeout still fires "expired" state if the session never appears.
- Resend button `redirectTo` updated to `\`${origin}/auth/callback?type=recovery\``.

### `app/auth/reset/page.tsx`
- Drops `code` from `searchParams` and the pass-through prop.
- Doc comment updated to describe the route-handler flow.

## What stays from #16
- `useCurrentUser` anonymous-bootstrap skip on `/auth/*`. Still defensive — future flows that claim sessions on `/auth/*` won't get clobbered.
- `RecoveryHashRouter` `?code=` query catcher. Safety net for the unlikely case Supabase falls back to Site URL with a code in the query string.

## Test plan
- [ ] Clear browser cookies for `greedypirate.com` first to flush any stale verifier / session state from the previous failed attempts.
- [ ] Click Forgot password → enter email → request.
- [ ] Inspect the inline link in the email — `&redirect_to=https://greedypirate.com/auth/callback?type=recovery`.
- [ ] Click "Reset Password" CTA → land at `/auth/reset` with the recovered session already in cookies, form prefilled with real email.
- [ ] Enter new password ≥ 8 chars → submit → land on `/profile?auth=password-reset` with success banner.
- [ ] Sign out, sign back in with new password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)