### PR TITLE
chore: profile polish + sticky reset-password loader

### DIFF
--- a/app/auth/reset/ResetPasswordForm.tsx
+++ b/app/auth/reset/ResetPasswordForm.tsx
@@ -119,11 +119,15 @@ export function ResetPasswordForm({ initialError }: Props) {
       setSubmitting(true);
       const supabase = getSupabaseBrowser();
       const { error: updateError } = await supabase.auth.updateUser({ password });
-      setSubmitting(false);
       if (updateError) {
+         setSubmitting(false);
          setFormError(updateError.message);
          return;
       }
+      // Leave submitting=true through the redirect — otherwise the
+      // button flips back to "Set new password" for a beat while
+      // router.push transitions, looking like nothing happened.
+      // Component unmounts on navigation, so the state never resets.
       emitProfileChanged();
       router.push('/profile?auth=password-reset');
       router.refresh();

--- a/app/profile/ProfileNameHeader.tsx
+++ b/app/profile/ProfileNameHeader.tsx
@@ -7,7 +7,6 @@ import { DisplayNameEditor } from '@/ui/display-name/DisplayNameEditor';
 interface Props {
    initialName: string;
    isAnonymous: boolean;
-   userIdShort?: string;
    size?: 'md' | 'lg';
 }
 
@@ -15,7 +14,7 @@ function initialsOf(name: string | undefined): string {
    return name?.trim()[0]?.toUpperCase() ?? 'P';
 }
 
-export function ProfileNameHeader({ initialName, isAnonymous, userIdShort, size = 'lg' }: Props) {
+export function ProfileNameHeader({ initialName, isAnonymous, size = 'lg' }: Props) {
    const [name, setName] = useState(initialName);
    const [editing, setEditing] = useState(false);
    const dim = size === 'lg' ? 'h-32 w-32' : 'h-24 w-24';
@@ -47,16 +46,16 @@ export function ProfileNameHeader({ initialName, isAnonymous, userIdShort, size 
                   type='button'
                   data-testid='profile-rename'
                   onClick={() => setEditing(true)}
-                  className='inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:var(--color-surface-border)] bg-[color:var(--color-abyss-900)]/60 text-[color:var(--color-cream-200)]/75 transition-colors hover:border-[color:var(--color-gold-500)]/60 hover:text-[color:var(--color-gold-300)]'
+                  className='inline-flex h-11 w-11 items-center justify-center rounded-full border border-[color:var(--color-surface-border)] bg-[color:var(--color-abyss-900)]/60 text-[color:var(--color-cream-200)]/85 transition-colors hover:border-[color:var(--color-gold-500)]/60 hover:text-[color:var(--color-gold-300)]'
                   aria-label='Edit display name'
                   title='Edit display name'
                >
-                  ✎
+                  <PencilIcon />
                </button>
             </div>
-            <p className='text-xs text-[color:var(--color-cream-200)]/55'>
-               {isAnonymous ? 'Guest crewmate' : userIdShort ? `Email account · ID ${userIdShort}` : 'Email account'}
-            </p>
+            {isAnonymous && (
+               <p className='text-xs text-[color:var(--color-cream-200)]/55'>Guest crewmate</p>
+            )}
          </header>
          <DisplayNameEditor
             open={editing}
@@ -66,5 +65,23 @@ export function ProfileNameHeader({ initialName, isAnonymous, userIdShort, size 
             onSaved={(next) => setName(next)}
          />
       </>
+   );
+}
+
+function PencilIcon() {
+   return (
+      <svg
+         viewBox='0 0 24 24'
+         className='h-6 w-6'
+         fill='none'
+         stroke='currentColor'
+         strokeWidth='2'
+         strokeLinecap='round'
+         strokeLinejoin='round'
+         aria-hidden='true'
+      >
+         <path d='M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4 12.5-12.5z' />
+         <path d='M15 5l4 4' />
+      </svg>
    );
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -111,12 +111,7 @@ export default async function ProfilePage({
             </div>
          )}
 
-         <ProfileNameHeader
-            initialName={displayName}
-            isAnonymous={false}
-            userIdShort={user.id.slice(0, 8)}
-            size='lg'
-         />
+         <ProfileNameHeader initialName={displayName} isAnonymous={false} size='lg' />
 
          {profile?.email && (
             <p className='-mt-3 text-center text-sm text-[color:var(--color-cream-200)]/65'>


### PR DESCRIPTION
## Summary
Three small UX fixes called out after the recovery flow shipped:

1. **Reset password button flashes back to idle** before redirect → keep the loader on until the new page actually navigates.
2. **`Email account · ID xxxxxxxx` line** on `/profile` exposes the internal user id for no reason → remove.
3. **Pencil edit button** on `/profile` uses a tiny unicode glyph in a 44px circle, hard to see → swap for a 24×24 SVG.

## Per-change breakdown

### `app/auth/reset/ResetPasswordForm.tsx`
- Only flip `submitting` back to `false` on the **error** path.
- On success, leave `submitting=true` and let component unmount during `router.push` clean it up.
- Result: button stays loading (showing the spinner from `PirateButton`) from click through navigation.

### `app/profile/ProfileNameHeader.tsx`
- Drop the `userIdShort` prop from the component (no callers will need it after this).
- Render the "Guest crewmate" caption only for anonymous users; non-anon users get nothing under their name (their email already shows below the header).
- Replace the unicode `✎` glyph with an inline 24×24 SVG pencil. `currentColor`-aware so the hover transition still works.
- Bump base text opacity from 75% to 85% so the icon reads more clearly against the dark surface.

### `app/profile/page.tsx`
- Drop the now-unused `userIdShort={user.id.slice(0, 8)}` from the `<ProfileNameHeader>` call.

## Test plan
- [ ] Reset password flow end-to-end → button stays in spinner state from click through landing on `/profile?auth=password-reset`. No flash to "Set new password" mid-flight.
- [ ] `/profile` as a claimed user → no "Email account · ID" line below the name. Email still appears below the stats grid (unchanged).
- [ ] `/profile` as a guest → still says "Guest crewmate".
- [ ] Pencil icon visibly larger inside the rename circle. Hover color still transitions to gold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)